### PR TITLE
Change container class' inside variable to be 64-bit for the Lua API

### DIFF
--- a/src/game_api/movable.hpp
+++ b/src/game_api/movable.hpp
@@ -115,7 +115,7 @@ class Player : public Monster
 class Container : public Movable
 {
   public:
-    int32_t inside;
+    int64_t inside;
     int32_t timer;
 };
 


### PR DESCRIPTION
Hopefully lets an entity's special attributes be more manipulable via the Lua API when it's more than 32 bits. 
This would let us manipulate arrows to make them poisoned and anything else with more than 32 bits used (e.g. bombs, crush traps) via the Lua API.
I've tested a build with this change and from what I've seen nothing was wrong.
I understand that the scripting API will change. This is just a quick and easy fix for a simple problem.