### PR TITLE
Add 16 bytes of padding to audio according to the FMOD docs

### DIFF
--- a/src/game_api/sound_manager.cpp
+++ b/src/game_api/sound_manager.cpp
@@ -491,7 +491,8 @@ CustomSound SoundManager::get_sound(std::string path)
         }
     }(new_sound.buffer.format);
 
-    FMOD::FMOD_RESULT err = m_CreateSound(m_FmodSystem, (const char*)new_sound.buffer.data.get(), mode, &create_sound_exinfo, &new_sound.fmod_sound);
+    auto data = (const char*)new_sound.buffer.data.get() + 16; // 16 bytes padding in front
+    FMOD::FMOD_RESULT err = m_CreateSound(m_FmodSystem, data, mode, &create_sound_exinfo, &new_sound.fmod_sound);
     if (err != FMOD::OK)
     {
         return CustomSound{nullptr, nullptr};

--- a/src/injected/decode_audio_file.cpp
+++ b/src/injected/decode_audio_file.cpp
@@ -14,10 +14,10 @@ DecodedAudioBuffer LoadAudioFile(const char* file_path)
     loader.Load(&decoded_data, file_path);
 
     const auto data_size = decoded_data.samples.size() * (GetFormatBitsPerSample(decoded_data.sourceFormat) / 8);
-    auto data = std::make_unique<std::byte[]>(data_size);
+    auto data = std::make_unique<std::byte[]>(data_size + 32); // 16 bytes padding front and back
     if (decoded_data.sourceFormat == nqr::PCM_FLT)
     {
-        memcpy(data.get(), decoded_data.samples.data(), data_size);
+        memcpy(data.get() + 16, decoded_data.samples.data(), data_size);
     }
     else
     {


### PR DESCRIPTION
This fixes a bug where fmod reads/writes out of the allocated buffer and sometimes that breaks audio, especially for short audio.