### PR TITLE
Adds NaN checks to crashing imgui draw functions

### DIFF
--- a/src/game_api/script/script_impl.cpp
+++ b/src/game_api/script/script_impl.cpp
@@ -153,13 +153,17 @@ ScriptImpl::ScriptImpl(std::string script, std::string file, SoundManager* sound
     /// Provides a read-only access to the save data, updated as soon as something changes (i.e. before it's written to savegame.sav.)
     lua["savegame"] = g_save;
 
+    /// Standard lua print function, prints directly to the console but not to the game
+    lua["lua_print"] = lua["print"];
     /// Print a log message on screen.
     lua["print"] = [this](std::string message) -> void
     {
         messages.push_back({message, std::chrono::system_clock::now(), ImVec4(1.0f, 1.0f, 1.0f, 1.0f)});
         if (messages.size() > 20)
             messages.pop_front();
+        lua["lua_print"](message);
     };
+
     /// Same as `print`
     lua["message"] = [this](std::string message) -> void
     { lua["print"](message); };

--- a/src/game_api/script/usertypes/gui_lua.cpp
+++ b/src/game_api/script/usertypes/gui_lua.cpp
@@ -39,6 +39,11 @@ void register_usertypes(sol::state& lua, ScriptImpl* script)
     {
         ImVec2 a = screenify({x1, y1});
         ImVec2 b = screenify({x2, y2});
+        // check for nan in the vectors because this will cause a crash in ImGui
+        if (isnan(a.x) || isnan(a.y) || isnan(b.x) || isnan(b.y))
+        {
+            return;
+        }
         script->draw_list->AddRectFilled(a, b, color, rounding, ImDrawCornerFlags_All);
     };
     /// Draws a circle on screen
@@ -46,6 +51,11 @@ void register_usertypes(sol::state& lua, ScriptImpl* script)
     {
         ImVec2 a = screenify({x, y});
         float r = screenify(radius);
+        // check for nan in the vectors and radius because this will cause a crash in ImGui
+        if (isnan(a.x) || isnan(a.y) || isnan(r))
+        {
+            return;
+        }
         script->draw_list->AddCircle(a, r, color, 0, thickness);
     };
     /// Draws a filled circle on screen

--- a/src/game_api/script/usertypes/gui_lua.cpp
+++ b/src/game_api/script/usertypes/gui_lua.cpp
@@ -27,6 +27,11 @@ void register_usertypes(sol::state& lua, ScriptImpl* script)
     {
         ImVec2 a = screenify({x1, y1});
         ImVec2 b = screenify({x2, y2});
+        // check for nan in the vectors because this will cause a crash in ImGui
+        if (isnan(a.x) || isnan(a.y) || isnan(b.x) || isnan(b.y))
+        {
+            return;
+        }
         script->draw_list->AddRect(a, b, color, rounding, ImDrawCornerFlags_All, thickness);
     };
     /// Draws a filled rectangle on screen from top-left to bottom-right.


### PR DESCRIPTION
New version of imgui crashes when a NaN is passed to one of the
arguments. The codepath that found this crash was to first measure
the text height when in fullscreen mode while alt-tabbed and then
feeding the output into draw_text.

Test Script:
```lua
set_callback(function()
    local x = 0
    local size = 24
    local text = "X"
    -- setting y directly won't cause a crash
    --local y = -0.5
    -- but using y as the result of a text_size causes a crash
    local text_w, text_height = draw_text_size(size, text)
    local y = text_height
    draw_rect(x, y, x+1, y, 2, 0, rgba(255,255,255,255))
end, ON.GUIFRAME)
```

Also updates imgui to latest in the docking branch