### PR TITLE
casts FLOOR_DOOR_ENTRANCE as floor

### DIFF
--- a/src/game_api/script/usertypes/entity_casting_lua.cpp
+++ b/src/game_api/script/usertypes/entity_casting_lua.cpp
@@ -31,7 +31,7 @@ void register_usertypes(sol::state& lua, ScriptImpl* script)
     lua["TYPE_MAP"][19] = lua["Entity"]["as_floor"]; // FLOOR_GROWABLE_VINE
     lua["TYPE_MAP"][20] = lua["Entity"]["as_floor"]; // FLOOR_CLIMBING_POLE
     lua["TYPE_MAP"][21] = lua["Entity"]["as_floor"]; // FLOOR_GROWABLE_CLIMBING_POLE
-    lua["TYPE_MAP"][22] = lua["Entity"]["as_floor"];  // FLOOR_DOOR_ENTRANCE
+    lua["TYPE_MAP"][22] = lua["Entity"]["as_floor"]; // FLOOR_DOOR_ENTRANCE
     // lua["TYPE_MAP"][23] = lua["Entity"]["as_exitdoor"];  // FLOOR_DOOR_EXIT (NOT IMPLEMENTED YET)
     // lua["TYPE_MAP"][24] = lua["Entity"]["as_mainexit"];  // FLOOR_DOOR_MAIN_EXIT (NOT IMPLEMENTED YET)
     // lua["TYPE_MAP"][25] = lua["Entity"]["as_exitdoor"];  // FLOOR_DOOR_STARTING_EXIT (NOT IMPLEMENTED YET)

--- a/src/game_api/script/usertypes/entity_casting_lua.cpp
+++ b/src/game_api/script/usertypes/entity_casting_lua.cpp
@@ -31,7 +31,7 @@ void register_usertypes(sol::state& lua, ScriptImpl* script)
     lua["TYPE_MAP"][19] = lua["Entity"]["as_floor"]; // FLOOR_GROWABLE_VINE
     lua["TYPE_MAP"][20] = lua["Entity"]["as_floor"]; // FLOOR_CLIMBING_POLE
     lua["TYPE_MAP"][21] = lua["Entity"]["as_floor"]; // FLOOR_GROWABLE_CLIMBING_POLE
-    lua["TYPE_MAP"][22] = lua["Entity"]["as_door"];  // FLOOR_DOOR_ENTRANCE
+    lua["TYPE_MAP"][22] = lua["Entity"]["as_floor"];  // FLOOR_DOOR_ENTRANCE
     // lua["TYPE_MAP"][23] = lua["Entity"]["as_exitdoor"];  // FLOOR_DOOR_EXIT (NOT IMPLEMENTED YET)
     // lua["TYPE_MAP"][24] = lua["Entity"]["as_mainexit"];  // FLOOR_DOOR_MAIN_EXIT (NOT IMPLEMENTED YET)
     // lua["TYPE_MAP"][25] = lua["Entity"]["as_exitdoor"];  // FLOOR_DOOR_STARTING_EXIT (NOT IMPLEMENTED YET)


### PR DESCRIPTION
instead of as_door. This was throwing an error when I was looping
through floor tiles at the start of the level:

```lua
set_callback(function()
    local filtered_uids = {}
    local x,y,l = get_position(players[1].uid)
    local radius = 5
    local uids = get_entities_at(0, MASK.FLOOR, x, y, l, radius)
    for i, uid in ipairs(uids) do
        -- this commented out code works but the one below does not
        --if get_entity_raw(uid).type.id ~= ENT_TYPE.FLOOR_BORDERTILE then
        prinspect(i, uid, get_entity_type(uid))
        if get_entity_type(uid) == ENT_TYPE.FLOOR_DOOR_ENTRANCE then

        end
        if get_entity(uid).type.id ~= ENT_TYPE.FLOOR_BORDERTILE then
            table.insert(filtered_uids, uid)
        end
    end
    prinspect(filtered_uids)
end, ON.LEVEL)
```

I think maybe FLOOR_DOOR_ENTRANCE isn't actually a door. It doesn't go
anywhere after all and is maybe totally visual?