### PR TITLE
set_max_velocity function

### DIFF
--- a/src/game_api/rpc.hpp
+++ b/src/game_api/rpc.hpp
@@ -84,3 +84,4 @@ void waddler_remove_entity(uint32_t entity_type, uint8_t amount_to_remove = 99);
 int16_t waddler_get_entity_meta(uint8_t slot);
 void waddler_set_entity_meta(uint8_t slot, int16_t meta);
 uint32_t waddler_entity_type_in_slot(uint8_t slot);
+void set_max_velocity(float max_positive_velocity, float max_negative_velocity);

--- a/src/game_api/script/script_impl.cpp
+++ b/src/game_api/script/script_impl.cpp
@@ -678,6 +678,10 @@ ScriptImpl::ScriptImpl(std::string script, std::string file, SoundManager* sound
     /// Note: The camera will still try to follow the player and this doesn't actually work at all.
     lua["set_camera_position"] = set_camera_position;
 
+    /// Sets the positive and negative max velocity. Note that the same value is shared for both the x-axis and y-axis.
+    /// Note: Max velocity in water will be exactly 1/5 of what you put in this function.
+    lua["set_max_velocity"] = set_max_velocity;
+
     /// Set a bit in a number. This doesn't actually change the bit in the entity you pass it, it just returns the new value you can use.
     lua["set_flag"] = [](Flags flags, int bit) -> Flags
     { return flags | (1U << (bit - 1)); };


### PR DESCRIPTION
Adds a function that sets the max velocity. The search methods I used are a little iffy I think

One of those max velocity variables has about 300 references (address 162277D3C in Ghidra, not sure if that's constant and/or the correct term :P). I'm not sure if this will cause any problems.
I have tested it a little and from what I've seen it works fine.

Edit: I think it's guaranteed to be problematic. MULSS, the instruction, takes m32 as its second operand. I can try putting in an offset to a static variable, but I don't know if that's possible and if it would work (nevermind, I just tried this and it didn't work). I'm too naive to be doing this stuff :/

