### PR TITLE
Clear timers on warp, make level callbacks better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 .vscode
 /cmake-build-debug/
 /cmake-build-relwithdebinfo/
-build
+build*
 out
 .vs

--- a/src/game_api/entities_items.hpp
+++ b/src/game_api/entities_items.hpp
@@ -453,7 +453,7 @@ class Container : public Movable
   public:
     uint32_t inside;
 
-    std::uint32_t set_on_open(std::function<void(Container*, Movable*)> on_open);
+    void set_on_open(std::uint32_t reserved_callback_id, std::function<void(Container*, Movable*)> on_open);
 };
 
 class Coffin : public Container

--- a/src/game_api/entity.cpp
+++ b/src/game_api/entity.cpp
@@ -398,25 +398,23 @@ void hook_movable_state_machine(Movable* self)
         },
         0x24);
 }
-std::uint32_t Movable::set_pre_statemachine(std::function<bool(Movable*)> pre_state_machine)
+void Movable::set_pre_statemachine(std::uint32_t reserved_callback_id, std::function<bool(Movable*)> pre_state_machine)
 {
     EntityHooksInfo& hook_info = get_hooks();
     if (hook_info.post_statemachine.empty())
     {
         hook_movable_state_machine(this);
     }
-    hook_info.pre_statemachine.push_back({hook_info.cbcount++, std::move(pre_state_machine)});
-    return hook_info.pre_statemachine.back().id;
+    hook_info.pre_statemachine.push_back({reserved_callback_id, std::move(pre_state_machine)});
 }
-std::uint32_t Movable::set_post_statemachine(std::function<void(Movable*)> post_state_machine)
+void Movable::set_post_statemachine(std::uint32_t reserved_callback_id, std::function<void(Movable*)> post_state_machine)
 {
     EntityHooksInfo& hook_info = get_hooks();
     if (hook_info.post_statemachine.empty())
     {
         hook_movable_state_machine(this);
     }
-    hook_info.post_statemachine.push_back({hook_info.cbcount++, std::move(post_state_machine)});
-    return hook_info.post_statemachine.back().id;
+    hook_info.post_statemachine.push_back({reserved_callback_id, std::move(post_state_machine)});
 }
 
 void Entity::destroy()
@@ -541,7 +539,12 @@ std::uint32_t Entity::set_on_destroy(std::function<void(Entity*)> cb)
     hook_info.on_destroy.push_back({hook_info.cbcount++, std::move(cb)});
     return hook_info.on_destroy.back().id;
 }
-std::uint32_t Entity::set_on_kill(std::function<void(Entity*, Entity*)> on_kill)
+std::uint32_t Entity::reserve_callback_id()
+{
+    EntityHooksInfo& hook_info = get_hooks();
+    return hook_info.cbcount++;
+}
+void Entity::set_on_kill(std::uint32_t reserved_callback_id, std::function<void(Entity*, Entity*)> on_kill)
 {
     EntityHooksInfo& hook_info = get_hooks();
     if (hook_info.on_kill.empty())
@@ -559,8 +562,7 @@ std::uint32_t Entity::set_on_kill(std::function<void(Entity*, Entity*)> on_kill)
             },
             0x2);
     }
-    hook_info.on_kill.push_back({hook_info.cbcount++, std::move(on_kill)});
-    return hook_info.on_kill.back().id;
+    hook_info.on_kill.push_back({reserved_callback_id, std::move(on_kill)});
 }
 
 bool Entity::is_movable()
@@ -574,7 +576,7 @@ bool Entity::is_movable()
     return false;
 }
 
-std::uint32_t Container::set_on_open(std::function<void(Container*, Movable*)> on_open)
+void Container::set_on_open(std::uint32_t reserved_callback_id, std::function<void(Container*, Movable*)> on_open)
 {
     EntityHooksInfo& hook_info = get_hooks();
     if (hook_info.on_open.empty())
@@ -595,6 +597,5 @@ std::uint32_t Container::set_on_open(std::function<void(Container*, Movable*)> o
             },
             0x17);
     }
-    hook_info.on_open.push_back({hook_info.cbcount++, std::move(on_open)});
-    return hook_info.on_open.back().id;
+    hook_info.on_open.push_back({reserved_callback_id, std::move(on_open)});
 }

--- a/src/game_api/entity.hpp
+++ b/src/game_api/entity.hpp
@@ -262,7 +262,8 @@ class Entity
     bool is_movable();
 
     std::uint32_t set_on_destroy(std::function<void(Entity*)> cb);
-    std::uint32_t set_on_kill(std::function<void(Entity*, Entity*)> on_kill);
+    std::uint32_t reserve_callback_id();
+    void set_on_kill(std::uint32_t reserved_callback_id, std::function<void(Entity*, Entity*)> on_kill);
 
     template <typename T>
     T* as()

--- a/src/game_api/movable.hpp
+++ b/src/game_api/movable.hpp
@@ -109,8 +109,8 @@ class Movable : public Entity
     bool is_button_held(uint32_t button);
     bool is_button_released(uint32_t button);
 
-    std::uint32_t set_pre_statemachine(std::function<bool(Movable*)> pre_state_machine);
-    std::uint32_t set_post_statemachine(std::function<void(Movable*)> post_state_machine);
+    void set_pre_statemachine(std::uint32_t reserved_callback_id, std::function<bool(Movable*)> pre_state_machine);
+    void set_post_statemachine(std::uint32_t reserved_callback_id, std::function<void(Movable*)> post_state_machine);
 };
 
 class PlayerTracker

--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -279,8 +279,13 @@ bool LuaBackend::update()
             {
                 if (now >= cb->lastRan + cb->interval)
                 {
-                    handle_function(cb->func);
+                    std::optional<bool> clear_me = handle_function_with_return<bool>(cb->func);
                     cb->lastRan = now;
+                    if (clear_me && clear_me.value() == false)
+                    {
+                        it = level_timers.erase(it);
+                        continue;
+                    }
                 }
                 ++it;
             }
@@ -404,8 +409,13 @@ bool LuaBackend::update()
             {
                 if (now_l >= cb->lastRan + cb->interval)
                 {
-                    handle_function(cb->func);
+                    std::optional<bool> clear_me = handle_function_with_return<bool>(cb->func);
                     cb->lastRan = now_l;
+                    if (clear_me && clear_me.value() == false)
+                    {
+                        it = level_timers.erase(it);
+                        continue;
+                    }
                 }
                 ++it;
             }

--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -186,11 +186,11 @@ bool LuaBackend::update()
             if (on_screen)
                 on_screen.value()();
         }
-        if (on_frame && g_state->time_level != state.time_level && g_state->screen == 12)
+        if (on_frame && g_state->time_level != state.time_level && g_state->screen == (int)ON::LEVEL)
         {
             on_frame.value()();
         }
-        if (g_state->screen == 11 && state.screen != 11)
+        if (g_state->screen == (int)ON::CAMP && state.screen != (int)ON::CAMP)
         {
             if (on_camp)
                 on_camp.value()();
@@ -205,17 +205,17 @@ bool LuaBackend::update()
             if (on_level)
                 on_level.value()();
         }
-        if (g_state->screen == 13 && state.screen != 13)
+        if (g_state->screen == (int)ON::TRANSITION && state.screen != (int)ON::TRANSITION)
         {
             if (on_transition)
                 on_transition.value()();
         }
-        if (g_state->screen == 14 && state.screen != 14)
+        if (g_state->screen == (int)ON::DEATH && state.screen != (int)ON::DEATH)
         {
             if (on_death)
                 on_death.value()();
         }
-        if ((g_state->screen == 16 && state.screen != 16) || (g_state->screen == 19 && state.screen != 19))
+        if ((g_state->screen == (int)ON::WIN && state.screen != (int)ON::WIN) || (g_state->screen == (int)ON::CONSTELLATION && state.screen != (int)ON::CONSTELLATION))
         {
             if (on_win)
                 on_win.value()();

--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -176,7 +176,7 @@ bool LuaBackend::update()
         std::vector<Player*> players = get_players();
         lua["players"] = std::vector<Player*>(players);
 
-        if (g_state->loading == 1 && g_state->loading != state.loading && g_state->screen != (int)ON::OPTIONS && g_state->screen_last != (int)ON::OPTIONS)
+        if (g_state->loading == 1 && g_state->loading != state.loading && g_state->screen_next != (int)ON::OPTIONS && g_state->screen != (int)ON::OPTIONS && g_state->screen_last != (int)ON::OPTIONS)
         {
             level_timers.clear();
             script_input.clear();

--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -283,7 +283,7 @@ bool LuaBackend::update()
                     cb->lastRan = now;
                     if (clear_me && clear_me.value() == false)
                     {
-                        it = level_timers.erase(it);
+                        it = global_timers.erase(it);
                         continue;
                     }
                 }

--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -176,10 +176,13 @@ bool LuaBackend::update()
         std::vector<Player*> players = get_players();
         lua["players"] = std::vector<Player*>(players);
 
-        if (g_state->screen != state.screen && g_state->screen_last != 5)
+        if (g_state->loading == 1 && g_state->loading != state.loading)
         {
             level_timers.clear();
             script_input.clear();
+        }
+        if (g_state->screen != state.screen && g_state->screen_last != 5)
+        {
             if (on_screen)
                 on_screen.value()();
         }
@@ -311,12 +314,12 @@ bool LuaBackend::update()
 
         for (auto& [id, callback] : callbacks)
         {
-            if ((ON)g_state->screen == callback.screen && g_state->screen != state.screen && g_state->screen_last != 5) // game screens
+            if ((ON)g_state->screen == callback.screen && g_state->screen != state.screen && g_state->screen_last != (int)ON::OPTIONS) // game screens
             {
                 handle_function(callback.func);
                 callback.lastRan = now;
             }
-            else if (callback.screen == ON::LEVEL && g_state->screen == (int)ON::LEVEL && g_state->screen_last != (int)ON::OPTIONS && !players.empty() && (state.player != players.at(0) || ((g_state->quest_flags & 1) == 0 && state.reset > 0)))
+            else if (callback.screen == ON::LEVEL && g_state->screen == (int)ON::LEVEL && state.loading != g_state->loading && g_state->loading == 3)
             {
                 handle_function(callback.func);
                 callback.lastRan = now;
@@ -355,8 +358,7 @@ bool LuaBackend::update()
                 }
                 case ON::START:
                 {
-                    if (g_state->screen == (int)ON::LEVEL && g_state->level_count == 0 && !players.empty() &&
-                        state.player != players.at(0))
+                    if (g_state->screen == (int)ON::LEVEL && g_state->level_count == 0 && state.loading != g_state->loading && g_state->loading == 3)
                     {
                         handle_function(callback.func);
                         callback.lastRan = now;

--- a/src/game_api/script/lua_backend.hpp
+++ b/src/game_api/script/lua_backend.hpp
@@ -247,6 +247,9 @@ class LuaBackend
     void draw(ImDrawList* dl);
     void render_options();
 
+    bool is_callback_cleared(int32_t callback_id);
+    bool is_entity_callback_cleared(std::pair<int, uint32_t> callback_id);
+
     bool pre_tile_code(std::string_view tile_code, float x, float y, int layer, uint16_t room_template);
     void post_tile_code(std::string_view tile_code, float x, float y, int layer, uint16_t room_template);
 

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -180,7 +180,7 @@ end
         }
     };
 
-    /// Returns unique id for the callback to be used in [clear_callback](#clear_callback).
+    /// Returns unique id for the callback to be used in [clear_callback](#clear_callback). You can also return `false` from your function to clear the callback.
     /// Add per level callback function to be called every `frames` engine frames. Timer is paused on pause and cleared on level transition.
     lua["set_interval"] = [](sol::function cb, int frames) -> CallbackId
     {
@@ -199,7 +199,7 @@ end
         backend->level_timers[backend->cbcount] = luaCb;
         return backend->cbcount++;
     };
-    /// Returns unique id for the callback to be used in [clear_callback](#clear_callback).
+    /// Returns unique id for the callback to be used in [clear_callback](#clear_callback). You can also return `false` from your function to clear the callback.
     /// Add global callback function to be called every `frames` engine frames. This timer is never paused or cleared.
     lua["set_global_interval"] = [](sol::function cb, int frames) -> CallbackId
     {

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -813,9 +813,14 @@ end
         if (Movable* movable = get_entity_ptr(uid)->as<Movable>())
         {
             LuaBackend* backend = LuaBackend::get_calling_backend();
-            std::uint32_t id = movable->set_pre_statemachine(
-                [backend, &lua, fun = std::move(fun)](Movable* self)
+            std::uint32_t id = movable->reserve_callback_id();
+            movable->set_pre_statemachine(
+                id,
+                [=, &lua, fun = std::move(fun)](Movable* self)
                 {
+                    if (backend->is_entity_callback_cleared({uid, id}))
+                        return false;
+
                     return backend->handle_function_with_return<bool>(fun, lua["cast_entity"](self)).value_or(false);
                 });
             backend->hook_entity_dtor(movable);
@@ -832,9 +837,14 @@ end
         if (Movable* movable = get_entity_ptr(uid)->as<Movable>())
         {
             LuaBackend* backend = LuaBackend::get_calling_backend();
-            std::uint32_t id = movable->set_post_statemachine(
-                [backend, &lua, fun = std::move(fun)](Movable* self)
+            std::uint32_t id = movable->reserve_callback_id();
+            movable->set_post_statemachine(
+                id,
+                [=, &lua, fun = std::move(fun)](Movable* self)
                 {
+                    if (backend->is_entity_callback_cleared({uid, id}))
+                        return;
+
                     backend->handle_function(fun, lua["cast_entity"](self));
                 });
             backend->hook_entity_dtor(movable);
@@ -852,9 +862,14 @@ end
         if (Entity* entity = get_entity_ptr(uid))
         {
             LuaBackend* backend = LuaBackend::get_calling_backend();
-            std::uint32_t id = entity->set_on_kill(
-                [backend, &lua, fun = std::move(fun)](Entity* self, Entity* killer)
+            std::uint32_t id = entity->reserve_callback_id();
+            entity->set_on_kill(
+                id,
+                [=, &lua, fun = std::move(fun)](Entity* self, Entity* killer)
                 {
+                    if (backend->is_entity_callback_cleared({uid, id}))
+                        return;
+
                     backend->handle_function(fun, lua["cast_entity"](self), lua["cast_entity"](killer));
                 });
             backend->hook_entity_dtor(entity);
@@ -873,9 +888,14 @@ end
         if (Container* entity = get_entity_ptr(uid)->as<Container>())
         {
             LuaBackend* backend = LuaBackend::get_calling_backend();
-            std::uint32_t id = entity->set_on_open(
-                [backend, &lua, fun = std::move(fun)](Entity* self, Movable* opener)
+            std::uint32_t id = entity->reserve_callback_id();
+            entity->set_on_open(
+                id,
+                [=, &lua, fun = std::move(fun)](Entity* self, Movable* opener)
                 {
+                    if (backend->is_entity_callback_cleared({uid, id}))
+                        return;
+
                     backend->handle_function(fun, lua["cast_entity"](self), lua["cast_entity"](opener));
                 });
             backend->hook_entity_dtor(entity);


### PR DESCRIPTION
After adding warps the timers were not cleared cause the screen never changes. Also the checks in onlevel were always a bit janky and I think they only worked 99.5%.

I think state.loading should work for both. Does this make more sense?

Also returning false from interval to clear it sounds neat as in #78 