### PR TITLE
add spawn_shopkeeper to make shops anywhere

### DIFF
--- a/docs/examples/spawn_roomowner.lua
+++ b/docs/examples/spawn_roomowner.lua
@@ -1,0 +1,7 @@
+-- spawns waddler selling pets
+-- all the aggro etc mechanics from a normal shop still apply
+local x, y, l = get_position(get_player(1).uid)
+local owner = spawn_roomowner(ENT_TYPE.MONS_STORAGEGUY, x+1, y, l, ROOM_TEMPLATE.SHOP)
+add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_DOG, x-1, y, l), owner)
+add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_CAT, x-2, y, l), owner)
+add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_HAMSTER, x-3, y, l), owner)

--- a/docs/examples/spawn_roomowner.lua
+++ b/docs/examples/spawn_roomowner.lua
@@ -5,3 +5,14 @@ local owner = spawn_roomowner(ENT_TYPE.MONS_STORAGEGUY, x+1, y, l, ROOM_TEMPLATE
 add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_DOG, x-1, y, l), owner)
 add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_CAT, x-2, y, l), owner)
 add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_HAMSTER, x-3, y, l), owner)
+
+-- use in a tile code to add shops to custom levels
+-- this may spawn some shop related decorations too
+define_tile_code("pet_shop_boys")
+set_pre_tile_code_callback(function(x, y, layer)
+    local owner = spawn_roomowner(ENT_TYPE.MONS_YANG, x, y, layer, ROOM_TEMPLATE.SHOP)
+    -- another dude for the meme, this has nothing to do with the shop
+    spawn_on_floor(ENT_TYPE.MONS_BODYGUARD, x+1, y, layer)
+    add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_HAMSTER, x+2, y, layer), owner)
+    return true
+end, "pet_shop_boys")

--- a/docs/examples/spawn_shopkeeper.lua
+++ b/docs/examples/spawn_shopkeeper.lua
@@ -1,0 +1,15 @@
+-- spawns a shopkeeper selling a shotgun next to you
+-- converts the current room to a ROOM_TEMPLATE.SHOP with shop music and zoom effect
+local x, y, l = get_position(get_player(1).uid)
+local owner = spawn_shopkeeper(x+1, y, l)
+add_item_to_shop(spawn_on_floor(ENT_TYPE.ITEM_SHOTGUN, x-1, y, l), owner)
+
+-- spawns a shopkeeper selling a puppy next to you
+-- also converts the room to a shop, but after the shopkeeper is spawned
+-- this enables the safe zone for moving items, but disables shop music and zoom for whatever reason
+local x, y, l = get_position(get_player(1).uid)
+local owner = spawn_shopkeeper(x+1, y, l, ROOM_TEMPLATE.SIDE)
+add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_DOG, x-1, y, l), owner)
+local ctx = PostRoomGenerationContext:new()
+local rx, ry = get_room_index(x, y)
+ctx:set_room_template(rx, ry, l, ROOM_TEMPLATE.SHOP)

--- a/examples/room_visualizer.lua
+++ b/examples/room_visualizer.lua
@@ -1,0 +1,42 @@
+meta.name = "Room visualizer"
+meta.version = "WIP"
+meta.description = "Shows shop zones, shop floors and other special room things."
+meta.author = "Dregu"
+
+set_callback(function(ctx)
+  local l = state.camera_layer
+  for rx=0,state.width-1 do
+    for ry=0,state.height-1 do
+      local rt = get_room_template(rx, ry, l)
+      local rn = get_room_template_name(rt)
+      if rt == 86 or rt == 87 or string.match(rn, "shop") or string.match(rn, "challenge") or string.match(rn, "vault") then
+        for x=rx*10+3.25,rx*10+12.25,0.5 do
+          for y=122.25-ry*8,122.25-ry*8-7,-0.5 do
+            local color = 0x000000ff
+            if is_inside_shop_zone(x, y, l) then color = 0xaa00ff00 end
+            local box = AABB:new(x-0.25, y+0.25, x+0.25, y-0.25)
+            local sbox = screen_aabb(box)
+            ctx:draw_rect_filled(sbox, 0, color)
+          end
+        end
+
+        for x=rx*10+3,rx*10+12,1 do
+          for y=122-ry*8,122-ry*8-7,-1 do
+            local color = 0x60000000
+            if is_inside_active_shop_room(x, y, l) then color = color | 0x00ff0000 end
+            local floor = get_grid_entity_at(x, y, l)
+            local box = AABB:new(x-0.5, y+0.5, x+0.5, y-0.5)
+            local sbox = screen_aabb(box)
+            if floor ~= -1 then
+              local ent = get_entity(floor)
+              if test_flag(ent.flags, ENT_FLAG.SHOP_FLOOR) then
+                color = color | 0x400000ff
+              end
+            end
+            ctx:draw_rect_filled(sbox, 0, color)
+          end
+        end
+      end
+    end
+  end
+end, ON.GUIFRAME)

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -1368,7 +1368,7 @@ end
         end
     )");
 
-    /// Spawn a shopkeeper in the coordinates and make the room a shop. Returns the shopkeeper uid.
+    /// Spawn a Shopkeeper in the coordinates and make the room their shop. Returns the Shopkeeper uid.
     // lua["spawn_shopkeeper"] = [](float x, float, y, LAYER layer, ROOM_TEMPLATE room_template = ROOM_TEMPLATE.SHOP) -> uint32_t
     lua["spawn_shopkeeper"] = sol::overload(
         [](float x, float y, LAYER layer)
@@ -1378,6 +1378,18 @@ end
         [](float x, float y, LAYER layer, ROOM_TEMPLATE room_template)
         {
             return spawn_shopkeeper(x, y, layer, room_template);
+        });
+
+    /// Spawn a RoomOwner in the coordinates and make them own the room, optionally changing the room template. Returns the RoomOwner uid.
+    // lua["spawn_roomowner"] = [](ENT_TYPE owner_type, float x, float, y, LAYER layer, ROOM_TEMPLATE room_template = -1) -> uint32_t
+    lua["spawn_roomowner"] = sol::overload(
+        [](ENT_TYPE owner_type, float x, float y, LAYER layer)
+        {
+            return spawn_roomowner(owner_type, x, y, layer);
+        },
+        [](ENT_TYPE owner_type, float x, float y, LAYER layer, int16_t room_template)
+        {
+            return spawn_roomowner(owner_type, x, y, layer, room_template);
         });
 
     lua.create_named_table("INPUTS", "NONE", 0, "JUMP", 1, "WHIP", 2, "BOMB", 4, "ROPE", 8, "RUN", 16, "DOOR", 32, "MENU", 64, "JOURNAL", 128, "LEFT", 256, "RIGHT", 512, "UP", 1024, "DOWN", 2048);

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -1368,7 +1368,7 @@ end
         end
     )");
 
-    /// Spawn a Shopkeeper in the coordinates and make the room their shop. Returns the Shopkeeper uid.
+    /// Spawn a Shopkeeper in the coordinates and make the room their shop. Returns the Shopkeeper uid. Also see spawn_roomowner.
     // lua["spawn_shopkeeper"] = [](float x, float, y, LAYER layer, ROOM_TEMPLATE room_template = ROOM_TEMPLATE.SHOP) -> uint32_t
     lua["spawn_shopkeeper"] = sol::overload(
         [](float x, float y, LAYER layer)
@@ -1380,7 +1380,7 @@ end
             return spawn_shopkeeper(x, y, layer, room_template);
         });
 
-    /// Spawn a RoomOwner in the coordinates and make them own the room, optionally changing the room template. Returns the RoomOwner uid.
+    /// Spawn a RoomOwner (or a few other like CavemanShopkeeper) in the coordinates and make them own the room, optionally changing the room template. Returns the RoomOwner uid.
     // lua["spawn_roomowner"] = [](ENT_TYPE owner_type, float x, float, y, LAYER layer, ROOM_TEMPLATE room_template = -1) -> uint32_t
     lua["spawn_roomowner"] = sol::overload(
         [](ENT_TYPE owner_type, float x, float y, LAYER layer)

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -3,8 +3,10 @@
 #include <csignal>
 
 #include "entities_items.hpp"
+#include "entities_monsters.hpp"
 #include "entity.hpp"
 #include "game_manager.hpp"
+#include "level_api.hpp"
 #include "online.hpp"
 #include "rpc.hpp"
 #include "spawn_api.hpp"
@@ -1365,6 +1367,18 @@ end
             end
         end
     )");
+
+    /// Spawn a shopkeeper in the coordinates and make the room a shop. Returns the shopkeeper uid.
+    // lua["spawn_shopkeeper"] = [](float x, float, y, LAYER layer, ROOM_TEMPLATE room_template = ROOM_TEMPLATE.SHOP) -> uint32_t
+    lua["spawn_shopkeeper"] = sol::overload(
+        [](float x, float y, LAYER layer)
+        {
+            return spawn_shopkeeper(x, y, layer);
+        },
+        [](float x, float y, LAYER layer, ROOM_TEMPLATE room_template)
+        {
+            return spawn_shopkeeper(x, y, layer, room_template);
+        });
 
     lua.create_named_table("INPUTS", "NONE", 0, "JUMP", 1, "WHIP", 2, "BOMB", 4, "ROPE", 8, "RUN", 16, "DOOR", 32, "MENU", 64, "JOURNAL", 128, "LEFT", 256, "RIGHT", 512, "UP", 1024, "DOWN", 2048);
 

--- a/src/game_api/spawn_api.cpp
+++ b/src/game_api/spawn_api.cpp
@@ -1,6 +1,7 @@
 #include "spawn_api.hpp"
 
 #include "entities_liquids.hpp"
+#include "entities_monsters.hpp"
 #include "entity.hpp"
 #include "layer.hpp"
 #include "level_api.hpp"
@@ -555,4 +556,21 @@ int32_t spawn_companion(ENT_TYPE companion_type, float x, float y, LAYER layer)
         return spawned->uid;
     }
     return -1;
+}
+
+int32_t spawn_shopkeeper(float x, float y, LAYER layer, ROOM_TEMPLATE room_template)
+{
+    const uint8_t real_layer = static_cast<int32_t>(layer) < 0 ? 0 : static_cast<uint8_t>(layer);
+    StateMemory* state_ptr = State::get().ptr();
+    auto [ix, iy] = state_ptr->level_gen->get_room_index(x, y);
+    uint32_t room_index = ix + iy * 8;
+    uint32_t keeper_uid = spawn_entity_abs_nonreplaceable(to_id("ENT_TYPE_MONS_SHOPKEEPER"), x, y, layer, 0, 0);
+    auto keeper = get_entity_ptr(keeper_uid)->as<Shopkeeper>();
+    keeper->shop_owner = true;
+    keeper->name = 0;
+    keeper->room_index = room_index;
+    state_ptr->level_gen->set_room_template(ix, iy, real_layer, room_template);
+    ShopOwnerDetails owner = {.layer = (uint8_t)layer, .room_index = room_index, .shop_owner_uid = keeper_uid};
+    state_ptr->shops.shop_owners.push_back(owner);
+    return keeper_uid;
 }

--- a/src/game_api/spawn_api.cpp
+++ b/src/game_api/spawn_api.cpp
@@ -567,7 +567,6 @@ int32_t spawn_shopkeeper(float x, float y, LAYER layer, ROOM_TEMPLATE room_templ
     uint32_t keeper_uid = spawn_entity_abs_nonreplaceable(to_id("ENT_TYPE_MONS_SHOPKEEPER"), x, y, layer, 0, 0);
     auto keeper = get_entity_ptr(keeper_uid)->as<Shopkeeper>();
     keeper->shop_owner = true;
-    keeper->name = 0;
     keeper->room_index = room_index;
     state_ptr->level_gen->set_room_template(ix, iy, real_layer, room_template);
     ShopOwnerDetails owner = {.layer = (uint8_t)layer, .room_index = room_index, .shop_owner_uid = keeper_uid};
@@ -577,13 +576,27 @@ int32_t spawn_shopkeeper(float x, float y, LAYER layer, ROOM_TEMPLATE room_templ
 
 int32_t spawn_roomowner(ENT_TYPE owner_type, float x, float y, LAYER layer, int16_t room_template)
 {
+    static const auto waddler_id = to_id("ENT_TYPE_MONS_STORAGEGUY");
+    static const auto shoppie_id = to_id("ENT_TYPE_MONS_SHOPKEEPER");
+    static const auto yang_id = to_id("ENT_TYPE_MONS_YANG");
+    static const auto tun_id = to_id("ENT_TYPE_MONS_MERCHANT");
+
     const uint8_t real_layer = static_cast<int32_t>(layer) < 0 ? 0 : static_cast<uint8_t>(layer);
     StateMemory* state_ptr = State::get().ptr();
     auto [ix, iy] = state_ptr->level_gen->get_room_index(x, y);
     uint32_t room_index = ix + iy * 8;
     uint32_t keeper_uid = spawn_entity_abs_nonreplaceable(owner_type, x, y, layer, 0, 0);
-    auto keeper = get_entity_ptr(keeper_uid)->as<RoomOwner>();
-    keeper->room_index = room_index;
+    if (owner_type == waddler_id || owner_type == yang_id || owner_type == tun_id)
+    {
+        auto keeper = get_entity_ptr(keeper_uid)->as<RoomOwner>();
+        keeper->room_index = room_index;
+    }
+    else if (owner_type == shoppie_id)
+    {
+        auto keeper = get_entity_ptr(keeper_uid)->as<Shopkeeper>();
+        keeper->shop_owner = true;
+        keeper->room_index = room_index;
+    }
     if (room_template >= 0)
         state_ptr->level_gen->set_room_template(ix, iy, real_layer, (uint16_t)room_template);
     ShopOwnerDetails owner = {.layer = (uint8_t)layer, .room_index = room_index, .shop_owner_uid = keeper_uid};

--- a/src/game_api/spawn_api.cpp
+++ b/src/game_api/spawn_api.cpp
@@ -574,3 +574,19 @@ int32_t spawn_shopkeeper(float x, float y, LAYER layer, ROOM_TEMPLATE room_templ
     state_ptr->shops.shop_owners.push_back(owner);
     return keeper_uid;
 }
+
+int32_t spawn_roomowner(ENT_TYPE owner_type, float x, float y, LAYER layer, int16_t room_template)
+{
+    const uint8_t real_layer = static_cast<int32_t>(layer) < 0 ? 0 : static_cast<uint8_t>(layer);
+    StateMemory* state_ptr = State::get().ptr();
+    auto [ix, iy] = state_ptr->level_gen->get_room_index(x, y);
+    uint32_t room_index = ix + iy * 8;
+    uint32_t keeper_uid = spawn_entity_abs_nonreplaceable(owner_type, x, y, layer, 0, 0);
+    auto keeper = get_entity_ptr(keeper_uid)->as<RoomOwner>();
+    keeper->room_index = room_index;
+    if (room_template >= 0)
+        state_ptr->level_gen->set_room_template(ix, iy, real_layer, (uint16_t)room_template);
+    ShopOwnerDetails owner = {.layer = (uint8_t)layer, .room_index = room_index, .shop_owner_uid = keeper_uid};
+    state_ptr->shops.shop_owners.push_back(owner);
+    return keeper_uid;
+}

--- a/src/game_api/spawn_api.cpp
+++ b/src/game_api/spawn_api.cpp
@@ -564,13 +564,13 @@ int32_t spawn_shopkeeper(float x, float y, LAYER layer, ROOM_TEMPLATE room_templ
     StateMemory* state_ptr = State::get().ptr();
     auto [ix, iy] = state_ptr->level_gen->get_room_index(x, y);
     uint32_t room_index = ix + iy * 8;
+    state_ptr->level_gen->set_room_template(ix, iy, real_layer, room_template);
     uint32_t keeper_uid = spawn_entity_abs_nonreplaceable(to_id("ENT_TYPE_MONS_SHOPKEEPER"), x, y, layer, 0, 0);
     auto keeper = get_entity_ptr(keeper_uid)->as<Shopkeeper>();
     keeper->shop_owner = true;
     keeper->room_index = room_index;
-    state_ptr->level_gen->set_room_template(ix, iy, real_layer, room_template);
-    ShopOwnerDetails owner = {.layer = (uint8_t)layer, .room_index = room_index, .shop_owner_uid = keeper_uid};
-    state_ptr->shops.shop_owners.push_back(owner);
+    // ShopOwnerDetails owner = {.layer = (uint8_t)layer, .room_index = room_index, .shop_owner_uid = keeper_uid};
+    // state_ptr->shops.shop_owners.push_back(owner);
     return keeper_uid;
 }
 
@@ -585,6 +585,8 @@ int32_t spawn_roomowner(ENT_TYPE owner_type, float x, float y, LAYER layer, int1
     StateMemory* state_ptr = State::get().ptr();
     auto [ix, iy] = state_ptr->level_gen->get_room_index(x, y);
     uint32_t room_index = ix + iy * 8;
+    if (room_template >= 0)
+        state_ptr->level_gen->set_room_template(ix, iy, real_layer, (uint16_t)room_template);
     uint32_t keeper_uid = spawn_entity_abs_nonreplaceable(owner_type, x, y, layer, 0, 0);
     if (owner_type == waddler_id || owner_type == yang_id || owner_type == tun_id)
     {
@@ -597,9 +599,7 @@ int32_t spawn_roomowner(ENT_TYPE owner_type, float x, float y, LAYER layer, int1
         keeper->shop_owner = true;
         keeper->room_index = room_index;
     }
-    if (room_template >= 0)
-        state_ptr->level_gen->set_room_template(ix, iy, real_layer, (uint16_t)room_template);
-    ShopOwnerDetails owner = {.layer = (uint8_t)layer, .room_index = room_index, .shop_owner_uid = keeper_uid};
-    state_ptr->shops.shop_owners.push_back(owner);
+    // ShopOwnerDetails owner = {.layer = (uint8_t)layer, .room_index = room_index, .shop_owner_uid = keeper_uid};
+    // state_ptr->shops.shop_owners.push_back(owner);
     return keeper_uid;
 }

--- a/src/game_api/spawn_api.hpp
+++ b/src/game_api/spawn_api.hpp
@@ -49,3 +49,4 @@ void init_spawn_hooks();
 void spawn_player(int8_t player_slot, float x, float y);
 int32_t spawn_companion(ENT_TYPE companion_type, float x, float y, LAYER layer);
 int32_t spawn_shopkeeper(float x, float y, LAYER layer, ROOM_TEMPLATE room_template = 65);
+int32_t spawn_roomowner(ENT_TYPE owner_type, float x, float y, LAYER layer, int16_t room_template = -1);

--- a/src/game_api/spawn_api.hpp
+++ b/src/game_api/spawn_api.hpp
@@ -48,3 +48,4 @@ void init_spawn_hooks();
 
 void spawn_player(int8_t player_slot, float x, float y);
 int32_t spawn_companion(ENT_TYPE companion_type, float x, float y, LAYER layer);
+int32_t spawn_shopkeeper(float x, float y, LAYER layer, ROOM_TEMPLATE room_template = 65);


### PR DESCRIPTION
This seems to work, would probably work for the other roomowners too.

Makes a shotgun shop where you're standing:
```lua
local x, y, l = get_position(get_player(1).uid)
add_item_to_shop(spawn_on_floor(ENT_TYPE.ITEM_SHOTGUN, x-1, y, l), spawn_shopkeeper(x+1, y, l))
```

Waddler selling puppies
```lua
local x, y, l = get_position(get_player(1).uid)
local owner = spawn_roomowner(ENT_TYPE.MONS_STORAGEGUY, x+1, y, l, ROOM_TEMPLATE.SHOP)
add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_DOG, x-1, y, l), owner)
add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_DOG, x-2, y, l), owner)
add_item_to_shop(spawn_on_floor(ENT_TYPE.MONS_PET_DOG, x-3, y, l), owner)
```