### PR TITLE
Return the callback id from pre_statemachine callback so that they can later be cleared.

### DIFF
--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -1061,6 +1061,7 @@ end
                 });
             backend->hook_entity_dtor(movable);
             backend->entity_hooks.push_back({uid, id});
+            return id;
         }
         return sol::nullopt;
     };


### PR DESCRIPTION
Fixes #209