### PR TITLE
Fix the TOAST and SPEECH_BUBBLE callbacks

### DIFF
--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -973,7 +973,6 @@ std::u16string LuaBackend::pre_speach_bubble(Entity* entity, char16_t* buffer)
             callback.lastRan = now;
             set_current_callback(-1, id, CallbackType::Normal);
             if (auto speech_value = handle_function_with_return<std::u16string>(callback.func, lua["cast_entity"](entity), buffer)) {
-                clear_current_callback();
                 if (!return_value) {
                     return_value = speech_value;
                 }
@@ -1004,7 +1003,6 @@ std::u16string LuaBackend::pre_toast(char16_t* buffer)
             callback.lastRan = now;
             set_current_callback(-1, id, CallbackType::Normal);
             if (auto toast_value = handle_function_with_return<std::u16string>(callback.func, buffer)) {
-                clear_current_callback();
                 if (!return_value) {
                     return_value = toast_value;
                 }

--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -972,8 +972,10 @@ std::u16string LuaBackend::pre_speach_bubble(Entity* entity, char16_t* buffer)
         {
             callback.lastRan = now;
             set_current_callback(-1, id, CallbackType::Normal);
-            if (auto speech_value = handle_function_with_return<std::u16string>(callback.func, lua["cast_entity"](entity), buffer)) {
-                if (!return_value) {
+            if (auto speech_value = handle_function_with_return<std::u16string>(callback.func, lua["cast_entity"](entity), buffer))
+            {
+                if (!return_value)
+                {
                     return_value = speech_value;
                 }
             }
@@ -1002,8 +1004,10 @@ std::u16string LuaBackend::pre_toast(char16_t* buffer)
         {
             callback.lastRan = now;
             set_current_callback(-1, id, CallbackType::Normal);
-            if (auto toast_value = handle_function_with_return<std::u16string>(callback.func, buffer)) {
-                if (!return_value) {
+            if (auto toast_value = handle_function_with_return<std::u16string>(callback.func, buffer))
+            {
+                if (!return_value)
+                {
                     return_value = toast_value;
                 }
             }

--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -961,6 +961,8 @@ std::u16string LuaBackend::pre_speach_bubble(Entity* entity, char16_t* buffer)
     auto now = get_frame_count();
     std::lock_guard lock{gil};
 
+    std::optional<std::u16string> return_value = std::nullopt;
+
     for (auto& [id, callback] : callbacks)
     {
         if (is_callback_cleared(id))
@@ -970,12 +972,16 @@ std::u16string LuaBackend::pre_speach_bubble(Entity* entity, char16_t* buffer)
         {
             callback.lastRan = now;
             set_current_callback(-1, id, CallbackType::Normal);
-            std::u16string return_value = handle_function_with_return<std::u16string>(callback.func, lua["cast_entity"](entity), buffer).value_or(std::u16string{no_return_str});
+            if (auto speech_value = handle_function_with_return<std::u16string>(callback.func, lua["cast_entity"](entity), buffer)) {
+                clear_current_callback();
+                if (!return_value) {
+                    return_value = speech_value;
+                }
+            }
             clear_current_callback();
-            return return_value;
         }
     }
-    return std::u16string{no_return_str};
+    return return_value.value_or(std::u16string{no_return_str});
 }
 
 std::u16string LuaBackend::pre_toast(char16_t* buffer)
@@ -986,6 +992,8 @@ std::u16string LuaBackend::pre_toast(char16_t* buffer)
     auto now = get_frame_count();
     std::lock_guard lock{gil};
 
+    std::optional<std::u16string> return_value = std::nullopt;
+
     for (auto& [id, callback] : callbacks)
     {
         if (is_callback_cleared(id))
@@ -995,12 +1003,16 @@ std::u16string LuaBackend::pre_toast(char16_t* buffer)
         {
             callback.lastRan = now;
             set_current_callback(-1, id, CallbackType::Normal);
-            std::u16string return_value = handle_function_with_return<std::u16string>(callback.func, buffer).value_or(std::u16string{no_return_str});
+            if (auto toast_value = handle_function_with_return<std::u16string>(callback.func, buffer)) {
+                clear_current_callback();
+                if (!return_value) {
+                    return_value = toast_value;
+                }
+            }
             clear_current_callback();
-            return return_value;
         }
     }
-    return std::u16string{no_return_str};
+    return return_value.value_or(std::u16string{no_return_str});
 }
 
 void LuaBackend::for_each_backend(std::function<bool(LuaBackend&)> fun)


### PR DESCRIPTION
Fix the TOAST and SPEECH_BUBBLE callbacks to continue running when the first one returns nil, and also to honor the promise made in the comment that all registered callbacks will be executed but only the first to return a value will actually matter.