### PR TITLE
Use storage floor in both layers, expose storage_uid

### DIFF
--- a/src/game_api/rpc.cpp
+++ b/src/game_api/rpc.cpp
@@ -744,6 +744,12 @@ void activate_sparktraps_hack(bool activate)
     }
 }
 
+void set_storage_layer(LAYER layer)
+{
+    if (layer == LAYER::FRONT || layer == LAYER::BACK)
+        write_mem_prot(get_address("storage_layer"), 0x1300 + 8 * (uint8_t)layer, true);
+}
+
 void set_kapala_blood_threshold(uint8_t threshold)
 {
     write_mem_prot(get_address("kapala_blood_threshold"), threshold, true);

--- a/src/game_api/rpc.hpp
+++ b/src/game_api/rpc.hpp
@@ -71,6 +71,7 @@ void set_seed(uint32_t seed);
 void set_arrowtrap_projectile(ENT_TYPE regular_entity_type, ENT_TYPE poison_entity_type);
 void modify_sparktraps(float angle_increment = 0.015, float distance = 3.0);
 void activate_sparktraps_hack(bool activate);
+void set_storage_layer(LAYER layer);
 void set_kapala_blood_threshold(uint8_t threshold);
 void set_kapala_hud_icon(int8_t icon_index);
 void set_blood_multiplication(uint32_t default_multiplier, uint32_t vladscape_multiplier);

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -819,6 +819,8 @@ end
     /// note: because those the variables are custom and game does not initiate then, you need to do it yourself for each spark, recommending `set_post_entity_spawn`
     /// default game values are: speed = -0.015, distance = 3.0
     lua["activate_sparktraps_hack"] = activate_sparktraps_hack;
+    /// Set layer to search for storage items on
+    lua["set_storage_layer"] = set_storage_layer;
     /// Sets the multiplication factor for blood droplets upon death (default/no Vlad's cape = 1, with Vlad's cape = 2)
     /// Due to changes in 1.23.x only the Vlad's cape value you provide will be used. The default is automatically Vlad's cape value - 1
     lua["set_blood_multiplication"] = set_blood_multiplication;

--- a/src/game_api/script/usertypes/state_lua.cpp
+++ b/src/game_api/script/usertypes/state_lua.cpp
@@ -455,8 +455,6 @@ void register_usertypes(sol::state& lua)
         &StateMemory::cause_of_death,
         "cause_of_death_entity_type",
         &StateMemory::cause_of_death_entity_type,
-        "storage_uid",
-        &StateMemory::waddler_floor_storage,
         "toast_timer",
         &StateMemory::toast_timer,
         "speechbubble_timer",
@@ -509,6 +507,7 @@ void register_usertypes(sol::state& lua)
         &StateMemory::arena,
         /* state got so big that adding stuff here will couse `compiler out of heap space`
         * to solve this, we add stuff in this comment for the autodoc, and then for real below to the `state_usertype`
+        * lol maybe we should remove this house of cards then and add stuff in a way that doesn't break the compiler when you add one little thing. and fix the autodoc.
 
         "speedrun_character",
         &StateMemory::speedrun_character,
@@ -536,6 +535,9 @@ void register_usertypes(sol::state& lua)
         &StateMemory::screen_change_counter,
         "time_startup",
         &StateMemory::time_startup,
+        "storage_uid",
+        &StateMemory::waddler_floor_storage,
+
         */
         "logic",
         &StateMemory::logic,
@@ -555,6 +557,7 @@ void register_usertypes(sol::state& lua)
     state_usertype["coffin_contents"] = &StateMemory::coffin_contents;
     state_usertype["screen_change_counter"] = &StateMemory::screen_change_counter;
     state_usertype["time_startup"] = &StateMemory::time_startup;
+    state_usertype["storage_uid"] = &StateMemory::waddler_floor_storage;
 
     lua.new_usertype<LightParams>(
         "LightParams",

--- a/src/game_api/script/usertypes/state_lua.cpp
+++ b/src/game_api/script/usertypes/state_lua.cpp
@@ -455,6 +455,8 @@ void register_usertypes(sol::state& lua)
         &StateMemory::cause_of_death,
         "cause_of_death_entity_type",
         &StateMemory::cause_of_death_entity_type,
+        "storage_uid",
+        &StateMemory::waddler_floor_storage,
         "toast_timer",
         &StateMemory::toast_timer,
         "speechbubble_timer",

--- a/src/game_api/search.cpp
+++ b/src/game_api/search.cpp
@@ -1596,8 +1596,8 @@ std::unordered_map<std::string_view, AddressRule> g_address_rules{
         // We're editing the layer offset in mov rcx,[r14+00001308]
         "storage_layer"sv,
         PatternCommandBuffer{}
-            .find_inst("\xe8\x43\x62\xb6\xff\x49\x8b\x8e"sv)
-            .offset(0x8)
+            .find_inst("\xf3\x0f\x10\x55\xe0\xf3\x0f\x10\x5d\xe4"sv)
+            .offset(-0x4)
             .at_exe(),
     },
 };

--- a/src/game_api/search.cpp
+++ b/src/game_api/search.cpp
@@ -1591,6 +1591,15 @@ std::unordered_map<std::string_view, AddressRule> g_address_rules{
             .at_exe()
             .function_start(),
     },
+    {
+        // Write bp on first waddler storage item in state
+        // We're editing the layer offset in mov rcx,[r14+00001308]
+        "storage_layer"sv,
+        PatternCommandBuffer{}
+            .find_inst("\xe8\x43\x62\xb6\xff\x49\x8b\x8e"sv)
+            .offset(0x8)
+            .at_exe()
+    }
 };
 std::unordered_map<std::string_view, size_t> g_cached_addresses;
 

--- a/src/game_api/search.cpp
+++ b/src/game_api/search.cpp
@@ -1598,8 +1598,8 @@ std::unordered_map<std::string_view, AddressRule> g_address_rules{
         PatternCommandBuffer{}
             .find_inst("\xe8\x43\x62\xb6\xff\x49\x8b\x8e"sv)
             .offset(0x8)
-            .at_exe()
-    }
+            .at_exe(),
+    },
 };
 std::unordered_map<std::string_view, size_t> g_cached_addresses;
 


### PR DESCRIPTION
Simply using `storage_floor` tilecode in the back layer of custom levels seems to mostly work as expected with CustomTheme. This PR

- adds `set_storage_layer(LAYER)` to patch a function that normally only searches the back layer for storage items. Well I hope that's all the function does...
- exposes `state.storage_uid` to enable/disable storage floor per level.

```lua
-- Spawn normal storage floor and set storage layer if waddler is happy, otherwise the floor to the left of this tile
set_post_tile_code_callback(function(x, y, layer)
    if not test_flag(state.quest_flags, 10) then
        set_storage_layer(layer)
    else
        local floor = get_entity(get_grid_entity_at(x, y, layer))
        if floor then
            floor:destroy()
        end
        if get_grid_entity_at(x - 1, y, layer) ~= -1 then
            local left = get_entity(get_grid_entity_at(x - 1, y, layer))
            spawn_grid_entity(left.type.id, x, y, layer)
        end
    end
end, "storage_floor")

-- Having a waddler is completely optional but this makes a nice waddler room if he still likes you
define_tile_code("waddler")
set_pre_tile_code_callback(function(x, y, layer)
    if not test_flag(state.quest_flags, 10) then
        local uid = spawn_roomowner(ENT_TYPE.MONS_STORAGEGUY, x + 0.5, y, layer, ROOM_TEMPLATE.WADDLER)
        set_on_kill(uid, function()
            -- Disable current level storage if you kill waddler
            state.storage_uid = -1
        end)
    end
    return true
end, "waddler")

-- This fixes a bug in the game that breaks storage on transition. The old storage_uid is not cleared after every level, maybe only after olmec etc?
set_callback(function()
    state.storage_uid = -1
end, ON.TRANSITION)
```