### PR TITLE
Auto updater

### DIFF
--- a/.github/workflows/whip-build.yml
+++ b/.github/workflows/whip-build.yml
@@ -47,3 +47,5 @@ jobs:
           title: "WHIP Build"
           files: |
             Overlunky_WHIP.zip
+            Overlunky/Overlunky.exe
+            Overlunky/injected.dll

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ An overlay for Spelunky 2 to help you with modding, exploring the depths of the 
 
 **Overlunky (or any other modding tool for that matter) does not support the GamePass/Xbox version**, but it might be considered in the future.
 
-[WHIP builds](https://github.com/spelunky-fyi/overlunky/releases/tag/whip) are whipped together automatically from the latest changes and are not tested or documented at all. They are mainly to keep up with the ever changing scripting api and usually contain bugfixes for that. Use at your own discretion, but if you want the latest scripts, get this. ![WHIP commits](https://img.shields.io/github/commits-since/spelunky-fyi/overlunky/latest)
-
 ## Disclaimer
 You are strongly discouraged from using any modding tools in your actual online Steam installation as to prevent unlocking achievements, ruining or corrupting your savefile and cheating while using online features. You should make a copy of your game somewhere else and install [Mr. Goldbergs Steam Emulator](https://mr_goldberg.gitlab.io/goldberg_emulator/) in the game directory. (Just replace steam_api64.dll with the one in the zip and that copy of the game can't talk to Steam no more!) If you break anything using this tool you get to keep both pieces. Do not report modding related bugs to BlitWorks.
 
@@ -21,11 +19,22 @@ You are strongly discouraged from using any modding tools in your actual online 
 ## Installation and usage
 **[YouTube tutorial](https://youtu.be/Zzba4cV9f2c) for kids who can't read good and who wanna learn to do other stuff good too.**
 
-**[Download the latest release](https://github.com/spelunky-fyi/overlunky/releases/latest)** and extract to your game folder. Run the program, leave it running and then start your game, or the other way around! Check the [keyboard shortcuts](#features) and [troubleshooting](#troubleshooting) before asking dumb questions. Overlunky doesn't do any permanent changes to your game, it only exists when you run it.
+**[Download the latest stable release](https://github.com/spelunky-fyi/overlunky/releases/latest)** (or a [WHIP build](https://github.com/spelunky-fyi/overlunky/releases/tag/whip) for more experimental stuff) and extract to your game folder, keeping the folder structure. Run the program, leave it running and then start your game, or the other way around! Check the [keyboard shortcuts](#features) and [troubleshooting](#troubleshooting) before asking dumb questions. Overlunky doesn't do any permanent changes to your game, it only exists when you run it.
 
 **Overlunky does NOT work online!** I thought the disclaimer was clear on this... Now I'm not going to stop you from trying, but you'll just find yourself in a world of desync and crashes.
 
 Check the generated `Spelunky 2/overlunky.ini` after running to change shortcut keys and check [entities.txt](https://github.com/spelunky-fyi/overlunky/blob/main/docs/game_data/entities.txt) for a list of numerical entity IDs.
+
+## WHIP build and automatic updates
+
+[WHIP builds](https://github.com/spelunky-fyi/overlunky/releases/tag/whip) are whipped together automatically from the latest changes and are not tested or documented at all. They are mainly to keep up with the ever changing scripting api and usually contain bugfixes for that. Use at your own discretion, but if you want to use the latest scripting features, get this.
+
+**WHIP also has an auto-update system to check for a new version on every launch. This only updates the DLL though, NOT the bundled example scripts or the launcher!** So:
+
+  - If you just want Overlunky for the tools, get the EXE and it will download the DLL and keep it updated for you
+  - If you want the bundled scripts or need to update the launcher, get the ZIP or use Modlunky2 to update everything
+
+![WHIP commits](https://img.shields.io/github/commits-since/spelunky-fyi/overlunky/latest)
 
 ## Features
 Current features and their *default* keyboard shortcuts. Note: There's a LOT of useful keys that are not listed here because this list is getting pretty long, check your `overlunky.ini` for cool beans. The default keys are also changed from time to time to make room for better features, so check the key config for your current keys, or delete the ini (section) to revert to default keys.

--- a/src/injector/main.cpp
+++ b/src/injector/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char** argv)
     INFO("Overlunky launcher version: {}", version);
 
     if (version.find(".") == std::string::npos)
-        auto_update("https://github.com/Dregu/overlunky/releases/download/whip/injected.dll", "injected.dll");
+        auto_update("https://github.com/spelunky-fyi/overlunky/releases/download/whip/injected.dll", "injected.dll");
     else
         INFO("AutoUpdate: Disabled on stable releases. Get the WHIP build to get automatic updates.");
 


### PR DESCRIPTION
I was just thinking of implementing an auto updater and came up with this. (So copied mostly from some chinese example, didn't even read most of it.)

- Added the exe and dll to the whip release assets so they can be downloaded separately
- Launcher checks for newer whip release from github (with winapi) and downloads a new dll if updated
- Launcher saves the modified header to a file to compare against next time
- Asks if you want to enable updates and update when a new one is found
- Disabled for stable releases and local builds

Doing http requests to dll files probably does increase AV false positives though 😿 