### PR TITLE
Fix infinite loop detection

### DIFF
--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -76,11 +76,15 @@ void populate_lua_state(sol::state& lua, SoundManager* sound_manager)
 {
     auto infinite_loop = [](lua_State* argst, [[maybe_unused]] lua_Debug* argdb)
     {
-        luaL_error(argst, "Hit Infinite Loop Detection of 1bln instructions");
+        static uint32_t last_frame = 0;
+        auto state = State::get().ptr();
+        if (last_frame == state->time_startup)
+            luaL_error(argst, "Hit Infinite Loop Detection of 1bln instructions");
+        last_frame = state->time_startup;
     };
 
     lua_sethook(lua.lua_state(), NULL, 0, 0);
-    lua_sethook(lua.lua_state(), infinite_loop, LUA_MASKCOUNT, 1000000000);
+    lua_sethook(lua.lua_state(), infinite_loop, LUA_MASKCOUNT, 500000000);
 
     lua.safe_script(R"(
 -- This function walks up the stack until it finds an _ENV that is not _G


### PR DESCRIPTION
This should be better and not fire all the time randomly. 500M instructions twice on the same frame to trigger, instead of 1B ever as it was before apparently.