### PR TITLE
Steam Overlay

### DIFF
--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -6660,6 +6660,7 @@ void imgui_draw()
                         ImGui::EndMenu();
                     }
                 }
+                ImGui::EndMainMenuBar();
             }
             ImGui::PopID();
         }


### PR DESCRIPTION
Apparently the d3d vtable hooks crash with steam overlay when using the viewports stuff, because steam overlay already had them hooked, so I hooked the steam overlay instead.

(As a side effect this enables the option to hide OL from OBS game capture if running on steam.)