### PR TITLE
Add a method to fix impostor lake positions to match the positions of the entities.

### DIFF
--- a/src/game_api/level_api.cpp
+++ b/src/game_api/level_api.cpp
@@ -1644,8 +1644,7 @@ void LevelGenSystem::init()
                     }
                 }
 
-                original(self, param_2, param_3, param_4);
-            },
+                original(self, param_2, param_3, param_4); },
             0xd);
         using DoProceduralSpawnFun = void(ThemeInfo*, SpawnInfo*);
         hook_vtable<DoProceduralSpawnFun>(
@@ -1659,8 +1658,7 @@ void LevelGenSystem::init()
                 {
                     return;
                 }
-                original(self, spawn_info);
-            },
+                original(self, spawn_info); },
             0x33);
     }
 }

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -671,6 +671,9 @@ end
     /// Spawns an impostor lake, `top_threshold` determines how much space on top is rendered as liquid but does not have liquid physics, fill that space with real liquid
     /// There needs to be other liquid in the level for the impostor lake to be visible, there can only be one impostor lake in the level
     lua["spawn_impostor_lake"] = spawn_impostor_lake;
+    /// NoDoc
+    /// Fixes the bounds of impostor lakes in the liquid physics engine to match the bounds of the impostor lake entities.
+    lua["fix_impostor_lake_positions"] = fix_impostor_lake_positions;
     /// Spawn a player in given location, if player of that slot already exist it will spawn clone, the game may crash as this is very unexpected situation
     /// If you want to respawn a player that is a ghost, set in his inventory `health` to above 0, and `time_of_death` to 0 and call this function, the ghost entity will be removed automatically
     lua["spawn_player"] = spawn_player;

--- a/src/game_api/spawn_api.cpp
+++ b/src/game_api/spawn_api.cpp
@@ -440,7 +440,8 @@ void setup_impostor_lake(Entity* lake_impostor, AABB aabb, float top_threshold)
 void fix_impostor_lake_positions()
 {
     auto state = get_state_ptr();
-    for (LiquidLake* lake = state->liquid_physics->start_lakes; lake < state->liquid_physics->end_lakes; lake++) {
+    for (LiquidLake* lake = state->liquid_physics->start_lakes; lake < state->liquid_physics->end_lakes; lake++)
+    {
         Entity* impostor_lake = lake->impostor_lake;
         auto [x_pos, y_pos] = impostor_lake->position();
         x_pos += impostor_lake->offsetx;

--- a/src/game_api/spawn_api.cpp
+++ b/src/game_api/spawn_api.cpp
@@ -440,9 +440,9 @@ void setup_impostor_lake(Entity* lake_impostor, AABB aabb, float top_threshold)
 void fix_impostor_lake_positions()
 {
     auto state = get_state_ptr();
-    for (LiquidLake* lake : state->liquid_physics->impostor_lakes)
+    for (auto& lake : state->liquid_physics->impostor_lakes)
     {
-        Entity* impostor_lake = lake->impostor_lake;
+        Entity* impostor_lake = lake.impostor_lake;
         auto [x_pos, y_pos] = impostor_lake->position();
         x_pos += impostor_lake->offsetx;
         y_pos += impostor_lake->offsety;
@@ -454,9 +454,9 @@ void fix_impostor_lake_positions()
         int32_t x3 = (int32_t)((x_pos + hitboxx + .5) * 3);
         x1 += x3;
         x3 = (int32_t)((y_pos + hitboxy + .5) * 3) * 0x102 + x3;
-        lake->position1 = x2;
-        lake->position2 = x1;
-        lake->position3 = x3;
+        lake.position1 = x2;
+        lake.position2 = x1;
+        lake.position3 = x3;
     }
 }
 

--- a/src/game_api/spawn_api.cpp
+++ b/src/game_api/spawn_api.cpp
@@ -440,7 +440,7 @@ void setup_impostor_lake(Entity* lake_impostor, AABB aabb, float top_threshold)
 void fix_impostor_lake_positions()
 {
     auto state = get_state_ptr();
-    for (LiquidLake* lake = state->liquid_physics->start_lakes; lake < state->liquid_physics->end_lakes; lake++)
+    for (LiquidLake* lake : state->liquid_physics->impostor_lakes)
     {
         Entity* impostor_lake = lake->impostor_lake;
         auto [x_pos, y_pos] = impostor_lake->position();

--- a/src/game_api/spawn_api.cpp
+++ b/src/game_api/spawn_api.cpp
@@ -437,6 +437,26 @@ void setup_impostor_lake(Entity* lake_impostor, AABB aabb, float top_threshold)
     setup_lake_impostor(lake_impostor, aabb.width() / 2.0f, aabb.height() / 2.0f, top_threshold);
 }
 
+void fix_impostor_lake_positions()
+{
+    auto state = get_state_ptr();
+    for (LiquidLake* lake = state->liquid_physics->start_lakes; lake < state->liquid_physics->end_lakes; lake++) {
+        Entity* impostor_lake = lake->impostor_lake;
+        float y_pos = impostor_lake->y + impostor_lake->offsety;
+        float x_pos = impostor_lake->x + impostor_lake->offsetx;
+        float hitboxx = impostor_lake->hitboxx;
+        float hitboxy = impostor_lake->hitboxy;
+        int32_t x1 = (int32_t)(y_pos - hitboxy + .5) * 3 * 0x102;
+        int32_t x2 = (int32_t)(x_pos - hitboxx + .5) * 3 + x1;
+        int32_t x3 = (int32_t)(x_pos + hitboxx + .5) * 3;
+        x1 += x3;
+        x3 = (int32_t)(y_pos + hitboxy + .5) * 3 * 0x102 + x3;
+        lake->position1 = x2;
+        lake->position2 = x1;
+        lake->position3 = x3;
+    }
+}
+
 void update_spawn_type_flags()
 {
     SPAWN_TYPE flags = 0;

--- a/src/game_api/spawn_api.cpp
+++ b/src/game_api/spawn_api.cpp
@@ -442,15 +442,17 @@ void fix_impostor_lake_positions()
     auto state = get_state_ptr();
     for (LiquidLake* lake = state->liquid_physics->start_lakes; lake < state->liquid_physics->end_lakes; lake++) {
         Entity* impostor_lake = lake->impostor_lake;
-        float y_pos = impostor_lake->y + impostor_lake->offsety;
-        float x_pos = impostor_lake->x + impostor_lake->offsetx;
+        auto [x_pos, y_pos] = impostor_lake->position();
+        x_pos += impostor_lake->offsetx;
+        y_pos += impostor_lake->offsety;
         float hitboxx = impostor_lake->hitboxx;
         float hitboxy = impostor_lake->hitboxy;
-        int32_t x1 = (int32_t)(y_pos - hitboxy + .5) * 3 * 0x102;
-        int32_t x2 = (int32_t)(x_pos - hitboxx + .5) * 3 + x1;
-        int32_t x3 = (int32_t)(x_pos + hitboxx + .5) * 3;
+        // Match the calculations that the game does when initializing these impostor objects.
+        int32_t x1 = (int32_t)((y_pos - hitboxy + .5) * 3) * 0x102;
+        int32_t x2 = (int32_t)((x_pos - hitboxx + .5) * 3) + x1;
+        int32_t x3 = (int32_t)((x_pos + hitboxx + .5) * 3);
         x1 += x3;
-        x3 = (int32_t)(y_pos + hitboxy + .5) * 3 * 0x102 + x3;
+        x3 = (int32_t)((y_pos + hitboxy + .5) * 3) * 0x102 + x3;
         lake->position1 = x2;
         lake->position2 = x1;
         lake->position3 = x3;

--- a/src/game_api/spawn_api.hpp
+++ b/src/game_api/spawn_api.hpp
@@ -40,6 +40,7 @@ int32_t spawn_mushroom(float x, float y, LAYER l, uint16_t height);
 
 Entity* spawn_impostor_lake(AABB aabb, LAYER layer, ENT_TYPE impostor_type, float top_threshold);
 void setup_impostor_lake(Entity* lake_imposter, AABB aabb, float top_threshold);
+void fix_impostor_lake_positions();
 
 void push_spawn_type_flags(SPAWN_TYPE flags);
 void pop_spawn_type_flags(SPAWN_TYPE flags);

--- a/src/game_api/state_structs.hpp
+++ b/src/game_api/state_structs.hpp
@@ -790,6 +790,15 @@ struct LiquidPool
     LiquidTileSpawnData tile_spawn_data;
 };
 
+struct LiquidLake
+{
+    uint32_t position1;
+    uint32_t position2;
+    uint32_t position3;
+    uint32_t lake_type;
+    Entity* impostor_lake;
+};
+
 struct LiquidPhysics
 {
     size_t unknown1; // MysteryLiquidPointer1 in plugin
@@ -815,6 +824,11 @@ struct LiquidPhysics
             LiquidTileSpawnData stagnant_lava_tile_spawn_data;
         };
     };
+    size_t unknown2;
+    size_t unknown3;
+    LiquidLake* start_lakes;
+    LiquidLake* end_lakes;
+    size_t unknown6;
 };
 
 struct AITarget

--- a/src/game_api/state_structs.hpp
+++ b/src/game_api/state_structs.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "aliases.hpp"
+#include "containers/custom_vector.hpp"
 #include <array>
 #include <cstdint>
 #include <set>
@@ -826,7 +827,7 @@ struct LiquidPhysics
     };
     size_t unknown2;
     size_t unknown3;
-    std::vector<LiquidLake> impostor_lakes;
+    custom_vector<LiquidLake> impostor_lakes;
     uint32_t total_liquid_spawned; // Total number of spawned liquid entities, all types.
     uint32_t unknown8;
     size_t unknown9;

--- a/src/game_api/state_structs.hpp
+++ b/src/game_api/state_structs.hpp
@@ -826,9 +826,16 @@ struct LiquidPhysics
     };
     size_t unknown2;
     size_t unknown3;
-    LiquidLake* start_lakes;
-    LiquidLake* end_lakes;
-    size_t unknown6;
+    std::vector<LiquidLake*> impostor_lakes;
+    uint32_t total_liquid_spawned; // Total number of spawned liquid entities, all types.
+    uint32_t unknown8;
+    size_t unknown9;
+    uint32_t total_liquid_spawned2; // Same as total_liquid_spawned?
+    bool unknown12;
+    uint8_t padding12a;
+    uint8_t padding12b;
+    uint8_t padding12c;
+    uint32_t unknown13;
 };
 
 struct AITarget

--- a/src/game_api/state_structs.hpp
+++ b/src/game_api/state_structs.hpp
@@ -826,7 +826,7 @@ struct LiquidPhysics
     };
     size_t unknown2;
     size_t unknown3;
-    std::vector<LiquidLake*> impostor_lakes;
+    std::vector<LiquidLake> impostor_lakes;
     uint32_t total_liquid_spawned; // Total number of spawned liquid entities, all types.
     uint32_t unknown8;
     size_t unknown9;


### PR DESCRIPTION
When impostor lake entities are moved, it only moves the blue rendering. This change adds a method to fix the positions of impostor lake water physics boxes to match the positions of the entities.