### PR TITLE
UI tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Current features and their *default* keyboard shortcuts.
       + **Ctrl+.**: Zoom out
       + **Ctrl+0**: Auto fit level width to screen
       + **Ctrl+2345**: Zoom to X level width
-      + **Shift+ArrowKey**: Move camera in desired direction
+      + **Shift+IJKL**: Move camera in desired direction
       + **Mouse 4**: Drag camera around or focus on an entity
       + **Mouse 4 longpress**: Reset camera focus to player
       + **Mouse 4+Wheel**: Zoom

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -1543,7 +1543,7 @@ void toggle_noclip()
     }
 }
 
-void force_noclip()
+void force_cheats()
 {
     g_players = UI::get_players();
     if (options["noclip"])
@@ -1576,6 +1576,24 @@ void force_noclip()
                     player->teleport_abs(cpos.first, cpos.second, player->velocityx, player->velocityy);
                 }
             }
+        }
+    }
+    static const auto ink = to_id("ENT_TYPE_FX_INK_BLINDNESS");
+    static const auto bubble = to_id("ENT_TYPE_FX_INK_BLINDNESS");
+    if (options["god_mode"])
+    {
+        for (auto ent : g_players)
+        {
+            // Remove icecage, stun, poison, curse, axo bubble, inkspit etc
+            ent->frozen_timer = 0;
+            ent->stun_timer = 0;
+            ent->poison_tick_timer = -1;
+            ent->onfire_effect_timer = 0;
+            ent->wet_effect_timer = 0;
+            ent->lock_input_timer = 0;
+            ent->set_cursed(false);
+            ent->more_flags &= ~(1U << 16);
+            UI::destroy_entity_item_type(ent, ink);
         }
     }
 }
@@ -6097,6 +6115,7 @@ void render_entity_props(int uid, bool detached = false)
             {
                 ImGui::CheckboxFlags(entity_type_properties_flags[i], &entity->type->properties_flags, (int)std::pow(2, i));
             }
+            endmenu();
         }
         endmenu();
     }
@@ -7250,7 +7269,7 @@ void post_draw()
     force_zoom();
     force_hud_flags();
     force_time();
-    force_noclip();
+    force_cheats();
     force_lights();
     frame_advance();
 }

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -1588,7 +1588,6 @@ void force_cheats()
         }
     }
     static const auto ink = to_id("ENT_TYPE_FX_INK_BLINDNESS");
-    static const auto bubble = to_id("ENT_TYPE_FX_INK_BLINDNESS");
     if (options["god_mode"])
     {
         for (auto ent : g_players)

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -3524,6 +3524,10 @@ void render_hitbox(Entity* ent, bool cross, ImColor color, bool filled = false)
         if (ent_spark->size >= 1.0)
             color = ImColor(255, 0, 0, 150);
     }
+    else if (ent->type->search_flags == 0x10) // Explosion
+    {
+        color = ImColor(255, 0, 0, 150);
+    }
     if (ent->shape == SHAPE::CIRCLE)
         if (filled)
             draw_list->AddCircleFilled(fix_pos(spos), sboxb.x - spos.x, color);
@@ -3549,9 +3553,11 @@ void render_hitbox(Entity* ent, bool cross, ImColor color, bool filled = false)
     if (type == spark_trap && ent->animation_frame == 7)
     {
         float distance = UI::get_spark_distance(ent->as<SparkTrap>());
+        auto thick = UI::screen_distance(0.55f);
+        auto sthick = screenify(thick);
         auto [radx, rady] = UI::screen_position(render_position.first + distance, render_position.second + distance);
         auto srad = screenify({radx, rady});
-        draw_list->AddCircle(fix_pos(spos), srad.x - spos.x, ImColor(255, 0, 0, 150), 0, 2.0f);
+        draw_list->AddCircle(fix_pos(spos), srad.x - spos.x, ImColor(255, 0, 0, 40), 0, sthick);
     }
     else if (type == bomb)
     {

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -46,6 +46,7 @@
 #include "savedata.hpp"
 #include "screen.hpp"
 #include "script.hpp"
+#include "settings_api.hpp"
 #include "sound_manager.hpp" // TODO: remove from here?
 #include "state.hpp"
 #include "version.hpp"
@@ -6892,6 +6893,11 @@ void imgui_draw()
 {
     auto base = ImGui::GetMainViewport();
     ImGuiContext& g = *GImGui;
+
+    if (get_setting(GAME_SETTING::WINDOW_MODE) == 0)
+        ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_ViewportsEnable;
+    else if (options["multi_viewports"])
+        ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
 
     for (int i = 1; i < g.PlatformIO.Viewports.Size; i++)
     {

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -81,6 +81,7 @@ std::map<std::string, int64_t> keys{
     {"toggle_mouse", OL_KEY_CTRL | 'M'},
     {"toggle_godmode", OL_KEY_CTRL | 'G'},
     {"toggle_noclip", OL_KEY_CTRL | 'F'},
+    {"toggle_flymode", OL_KEY_CTRL | OL_KEY_SHIFT | 'F'},
     {"toggle_snap", OL_KEY_CTRL | 'S'},
     {"toggle_pause", OL_KEY_CTRL | VK_SPACE},
     {"toggle_disable_pause", OL_KEY_CTRL | OL_KEY_SHIFT | 'P'},
@@ -297,6 +298,7 @@ std::map<std::string, bool> options = {
     {"god_mode", false},
     {"god_mode_companions", false},
     {"noclip", false},
+    {"fly_mode", false},
     {"snap_to_grid", false},
     {"spawn_floor_decorated", true},
     {"disable_pause", false},
@@ -1596,6 +1598,15 @@ void force_cheats()
             UI::destroy_entity_item_type(ent, ink);
         }
     }
+    if (options["fly_mode"])
+    {
+        for (auto ent : g_players)
+        {
+            auto player = (Movable*)(ent->topmost_mount());
+            if ((player->buttons & 1) == 1 && player->velocityy < 0.18f)
+                player->velocityy = 0.18f;
+        }
+    }
 }
 
 void force_kits()
@@ -2268,6 +2279,10 @@ bool process_keys(UINT nCode, WPARAM wParam, [[maybe_unused]] LPARAM lParam)
     {
         options["noclip"] = !options["noclip"];
         toggle_noclip();
+    }
+    else if (pressed("toggle_flymode", wParam))
+    {
+        options["fly_mode"] = !options["fly_mode"];
     }
     else if (pressed("toggle_hitboxes", wParam))
     {
@@ -4668,6 +4683,8 @@ void render_options()
             toggle_noclip();
         }
         tooltip("Fly through walls and ignored by enemies.", "toggle_noclip");
+        ImGui::Checkbox("Fly mode##FlyMode", &options["fly_mode"]);
+        tooltip("Fly while holding the jump button.", "toggle_flymode");
         ImGui::Checkbox("Light dark levels and layers##DrawLights", &options["lights"]);
         tooltip("Enables the default level lighting everywhere.", "toggle_lights");
         if (ImGui::CheckboxFlags("Force dark levels", &g_dark_mode, 1))
@@ -6919,7 +6936,7 @@ void render_prohud()
     ImVec2 textsize = ImGui::CalcTextSize(buf.c_str());
     dl->AddText({base->Pos.x + base->Size.x / 2 - textsize.x / 2, base->Pos.y + 2 + topmargin}, ImColor(1.0f, 1.0f, 1.0f, .5f), buf.c_str());
 
-    buf = fmt::format("{}{}{}{}{}{}{}{}{}{}{}{}{}{}", (options["god_mode"] ? "GODMODE " : ""), (options["god_mode_companions"] ? "HHGODMODE " : ""), (options["noclip"] ? "NOCLIP " : ""), (options["lights"] ? "LIGHTS " : ""), (test_flag(g_dark_mode, 1) ? "DARK " : ""), (test_flag(g_dark_mode, 2) ? "NODARK " : ""), (options["disable_ghost_timer"] ? "NOGHOST " : ""), (options["disable_achievements"] ? "NOSTEAM " : ""), (options["disable_savegame"] ? "NOSAVE " : ""), (options["disable_pause"] ? "NOPAUSE " : ""), (g_zoom != 13.5 ? fmt::format("ZOOM:{} ", g_zoom) : ""), (g_speedhack_multiplier != 1.0 ? fmt::format("SPEEDHACK:{} ", g_speedhack_multiplier) : ""), (!options["mouse_control"] ? "NOMOUSE " : ""), (!options["keyboard_control"] ? "NOKEYBOARD " : ""));
+    buf = fmt::format("{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", (options["god_mode"] ? "GODMODE " : ""), (options["god_mode_companions"] ? "HHGODMODE " : ""), (options["noclip"] ? "NOCLIP " : ""), (options["fly_mode"] ? "FLY " : ""), (options["lights"] ? "LIGHTS " : ""), (test_flag(g_dark_mode, 1) ? "DARK " : ""), (test_flag(g_dark_mode, 2) ? "NODARK " : ""), (options["disable_ghost_timer"] ? "NOGHOST " : ""), (options["disable_achievements"] ? "NOSTEAM " : ""), (options["disable_savegame"] ? "NOSAVE " : ""), (options["disable_pause"] ? "NOPAUSE " : ""), (g_zoom != 13.5 ? fmt::format("ZOOM:{} ", g_zoom) : ""), (g_speedhack_multiplier != 1.0 ? fmt::format("SPEEDHACK:{} ", g_speedhack_multiplier) : ""), (!options["mouse_control"] ? "NOMOUSE " : ""), (!options["keyboard_control"] ? "NOKEYBOARD " : ""));
     textsize = ImGui::CalcTextSize(buf.c_str());
     dl->AddText({base->Pos.x + base->Size.x / 2 - textsize.x / 2, base->Pos.y + textsize.y + 4 + topmargin}, ImColor(1.0f, 1.0f, 1.0f, .5f), buf.c_str());
 

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -139,10 +139,10 @@ std::map<std::string, int64_t> keys{
     {"teleport_up", 0x0},
     {"teleport_right", 0x0},
     {"teleport_down", 0x0},
-    {"camera_left", OL_KEY_SHIFT | VK_LEFT},
-    {"camera_up", OL_KEY_SHIFT | VK_UP},
-    {"camera_right", OL_KEY_SHIFT | VK_RIGHT},
-    {"camera_down", OL_KEY_SHIFT | VK_DOWN},
+    {"camera_left", OL_KEY_SHIFT | 'J'},
+    {"camera_up", OL_KEY_SHIFT | 'I'},
+    {"camera_right", OL_KEY_SHIFT | 'L'},
+    {"camera_down", OL_KEY_SHIFT | 'K'},
     {"coordinate_left", 0x0},
     {"coordinate_up", 0x0},
     {"coordinate_right", 0x0},
@@ -2345,29 +2345,37 @@ bool process_keys(UINT nCode, WPARAM wParam, [[maybe_unused]] LPARAM lParam)
     }
     else if (pressed("camera_left", wParam))
     {
-        if (g_state->camera->focused_entity_uid == -1)
-            g_state->camera->focus_x -= 0.2f;
+        enable_camera_bounds = false;
+        set_camera_bounds(enable_camera_bounds);
+        g_state->camera->focused_entity_uid = -1;
+        g_state->camera->focus_x -= 0.5f;
         if (g_state->pause != 0 || !options["smooth_camera"])
             g_state->camera->adjusted_focus_x = g_state->camera->focus_x;
     }
     else if (pressed("camera_right", wParam))
     {
-        if (g_state->camera->focused_entity_uid == -1)
-            g_state->camera->focus_x += 0.2f;
+        enable_camera_bounds = false;
+        set_camera_bounds(enable_camera_bounds);
+        g_state->camera->focused_entity_uid = -1;
+        g_state->camera->focus_x += 0.5f;
         if (g_state->pause != 0 || !options["smooth_camera"])
             g_state->camera->adjusted_focus_x = g_state->camera->focus_x;
     }
     else if (pressed("camera_up", wParam))
     {
-        if (g_state->camera->focused_entity_uid == -1)
-            g_state->camera->focus_y += 0.2f;
+        enable_camera_bounds = false;
+        set_camera_bounds(enable_camera_bounds);
+        g_state->camera->focused_entity_uid = -1;
+        g_state->camera->focus_y += 0.5f;
         if (g_state->pause != 0 || !options["smooth_camera"])
             g_state->camera->adjusted_focus_y = g_state->camera->focus_y;
     }
     else if (pressed("camera_down", wParam))
     {
-        if (g_state->camera->focused_entity_uid == -1)
-            g_state->camera->focus_y -= 0.2f;
+        enable_camera_bounds = false;
+        set_camera_bounds(enable_camera_bounds);
+        g_state->camera->focused_entity_uid = -1;
+        g_state->camera->focus_y -= 0.5f;
         if (g_state->pause != 0 || !options["smooth_camera"])
             g_state->camera->adjusted_focus_y = g_state->camera->focus_y;
     }

--- a/src/injected/ui_util.cpp
+++ b/src/injected/ui_util.cpp
@@ -346,6 +346,26 @@ int32_t UI::destroy_entity_items(Entity* ent)
     }
     return last_uid;
 }
+bool UI::destroy_entity_item_type(Entity* ent, ENT_TYPE type)
+{
+    auto items = entity_get_items_by(ent->uid, 0, 0);
+    if (items.size() == 0)
+        return false;
+    auto destroyed = false;
+    std::vector<uint32_t>::reverse_iterator it = items.rbegin();
+    while (it != items.rend())
+    {
+        auto item = get_entity_ptr(*it);
+        if (item && item->type->id == type)
+        {
+            UI::destroy_entity_items(item);
+            UI::safe_destroy(item, false, false);
+            destroyed = true;
+        }
+        it++;
+    }
+    return destroyed;
+}
 void UI::destroy_entity_overlay(Entity* ent)
 {
     while (ent->overlay)

--- a/src/injected/ui_util.cpp
+++ b/src/injected/ui_util.cpp
@@ -93,6 +93,12 @@ std::pair<float, float> UI::screen_position(float x, float y)
 {
     return State::screen_position(x, y);
 }
+float UI::screen_distance(float x)
+{
+    auto a = State::screen_position(0, 0);
+    auto b = State::screen_position(x, 0);
+    return b.first - a.first;
+}
 Entity* UI::get_entity_at(float x, float y, bool s, float radius, uint32_t mask)
 {
     auto state = State::get();

--- a/src/injected/ui_util.hpp
+++ b/src/injected/ui_util.hpp
@@ -72,6 +72,7 @@ class UI
     static std::optional<uint16_t> get_room_template(uint32_t x, uint32_t y, uint8_t l);
     static void steam_achievements(bool on);
     static int32_t destroy_entity_items(Entity* ent);
+    static bool destroy_entity_item_type(Entity* ent, ENT_TYPE type);
     static void destroy_entity_overlay(Entity* ent);
     static void kill_entity_overlay(Entity* ent);
     static void update_floor_at(float x, float y, LAYER l);

--- a/src/injected/ui_util.hpp
+++ b/src/injected/ui_util.hpp
@@ -45,6 +45,7 @@ class UI
     static float get_zoom_level();
     static void teleport(float x, float y, bool s, float vx, float vy, bool snap);
     static std::pair<float, float> screen_position(float x, float y);
+    static float screen_distance(float x);
     static Entity* get_entity_at(float x, float y, bool s, float radius, uint32_t mask);
     static void move_entity(uint32_t uid, float x, float y, bool s, float vx, float vy, bool snap);
     static SaveData* savedata();


### PR DESCRIPTION
- Disable viewports in exclusive fullscreen
- Make spark hitbox thicc
- Render subsections in menu-ui as submenus
- Change default camera move keys
- Make godmode disable any negative effects
- Add fly mode
- Add automatic speedhack to speed up menuing and transitions