### PR TITLE
Only set camera bounds when toggling

### DIFF
--- a/src/game_api/search.cpp
+++ b/src/game_api/search.cpp
@@ -375,13 +375,13 @@ class PatternCommandBuffer
                 break;
             case CommandType::DecodePC:
                 offset = std::apply([=](auto... args)
-                { return ::decode_pc(exe, offset, args...); },
-                    data.decode_pc_args.as_tuple());
+                                    { return ::decode_pc(exe, offset, args...); },
+                                    data.decode_pc_args.as_tuple());
                 break;
             case CommandType::DecodeIMM:
                 offset = std::apply([=](auto... args)
-                { return ::decode_imm(exe, offset, args...); },
-                    data.decode_imm_args.as_tuple());
+                                    { return ::decode_imm(exe, offset, args...); },
+                                    data.decode_imm_args.as_tuple());
                 break;
             case CommandType::DecodeCall:
                 offset = mem.decode_call(offset);
@@ -407,7 +407,7 @@ class PatternCommandBuffer
         return offset;
     }
 
-private:
+  private:
     struct DecodePcArgs
     {
         uint8_t opcode_offset;
@@ -416,7 +416,7 @@ private:
 
         std::tuple<uint8_t, uint8_t, uint8_t> as_tuple() const
         {
-            return { opcode_offset, opcode_suffix_offset, opcode_addr_size };
+            return {opcode_offset, opcode_suffix_offset, opcode_addr_size};
         }
     };
     struct DecodeImmArgs
@@ -426,7 +426,7 @@ private:
 
         std::tuple<uint8_t, uint8_t> as_tuple() const
         {
-            return { opcode_offset, value_size };
+            return {opcode_offset, value_size};
         }
     };
     struct FindInstArgs

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -1568,8 +1568,6 @@ void set_camera_bounds(bool enabled)
 
 void force_zoom()
 {
-    if (g_state->screen == 12)
-        set_camera_bounds(enable_camera_bounds);
     if (g_zoom == 0.0f && g_state != 0 && (g_state->w != g_level_width) && (g_state->screen == 11 || g_state->screen == 12))
     {
         set_zoom();


### PR DESCRIPTION
The game actively manages `camera->bounds_bottom` in some levels, most obviously Hundun. #287 included a change that set the bounds on every frame (in commit `cbe954f`). Since the `bounds_bottom` it sets assumes a typical level, and it's called after the game sets `bounds_bottom`, the result is the bounds being "too low".

To address this problem, this PR removes setting the bounds on every frame. I think this re-introduces jank when the game is adjusting the bounds, e.g. you can move the camera down and it'll be pulled back up if the game sets `bounds_bottom`.

I considered only setting `bounds_bottom` if it was `-FLT_MAX`, but that seems really weird. I haven't thought of any other options.