### PR TITLE
Edit Steam achievements

### DIFF
--- a/src/game_api/steam_api.cpp
+++ b/src/game_api/steam_api.cpp
@@ -48,6 +48,38 @@ void disable_steam_achievements()
     }
 }
 
+bool get_steam_achievement(const char* achievement_id, bool* achieved)
+{
+    ISteamUserStats* steam_user_stats = get_steam_user_stats();
+    if (steam_user_stats != nullptr)
+    {
+        using ISteamUserStats_GetAchievement = bool(ISteamUserStats*, const char*, bool*);
+        ISteamUserStats_GetAchievement* get_achievement = *vtable_find<ISteamUserStats_GetAchievement*>(steam_user_stats, 0x6);
+        return get_achievement(steam_user_stats, achievement_id, achieved);
+    }
+    return false;
+}
+
+bool set_steam_achievement(const char* achievement_id, bool achieved)
+{
+    ISteamUserStats* steam_user_stats = get_steam_user_stats();
+    if (steam_user_stats != nullptr)
+    {
+        if (achieved)
+        {
+            using ISteamUserStats_SetAchievement = bool(ISteamUserStats*, const char*);
+            ISteamUserStats_SetAchievement* set_achievement = *vtable_find<ISteamUserStats_SetAchievement*>(steam_user_stats, 0x7);
+            return set_achievement(steam_user_stats, achievement_id);
+        }
+        else
+        {
+            using ISteamUserStats_ResetAchievement = bool(ISteamUserStats*, const char*);
+            ISteamUserStats_ResetAchievement* reset_achievement = *vtable_find<ISteamUserStats_ResetAchievement*>(steam_user_stats, 0x8);
+            return reset_achievement(steam_user_stats, achievement_id);
+        }
+    }
+    return false;
+}
 void reset_all_steam_achievements()
 {
     ISteamUserStats* steam_user_stats = get_steam_user_stats();

--- a/src/game_api/steam_api.hpp
+++ b/src/game_api/steam_api.hpp
@@ -81,3 +81,5 @@ std::tuple<bool, bool, const char16_t*, const char16_t*> get_feat(FEAT feat);
 bool get_feat_hidden(FEAT feat);
 void set_feat_hidden(FEAT feat, bool hidden);
 void init_achievement_hooks();
+bool get_steam_achievement(const char* achievement_id, bool* achieved);
+bool set_steam_achievement(const char* achievement_id, bool achieved);


### PR DESCRIPTION
Adds checkboxes under Savegame menu to see and edit Steam achievements directly so you can at least try to undo the damage done by not blocking them in the first place, or I guess cheat if you want to, I'm not your mom.