### PR TITLE
Move ON.SAVE callbacks to run last.

### DIFF
--- a/src/game_api/script/lua_backend.hpp
+++ b/src/game_api/script/lua_backend.hpp
@@ -270,6 +270,7 @@ class LuaBackend
     std::unordered_map<int, TimerCallback> global_timers;
     std::unordered_map<int, ScreenCallback> callbacks;
     std::unordered_map<int, ScreenCallback> load_callbacks;
+    std::unordered_map<int, ScreenCallback> save_callbacks;
     std::vector<std::uint32_t> vanilla_sound_callbacks;
     std::vector<LevelGenCallback> pre_tile_code_callbacks;
     std::vector<LevelGenCallback> post_tile_code_callbacks;

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -365,6 +365,8 @@ end
         auto luaCb = ScreenCallback{cb, event, -1};
         if (luaCb.screen == ON::LOAD)
             backend->load_callbacks[backend->cbcount] = luaCb; // Make sure load always runs before other callbacks
+        else if (luaCb.screen == ON::SAVE)
+            backend->save_callbacks[backend->cbcount] = luaCb; // Make sure save always runs after other callbacks
         else
             backend->callbacks[backend->cbcount] = luaCb;
         return backend->cbcount++;


### PR DESCRIPTION
Currently if you call save_script or save_progress from a callback that runs after ON.SAVE it will update your last_save time but not actually run the ON.SAVE callback.

This moves ON.SAVE callbacks into their own vector that always run last so manual saves work from any other callbacks.