### PR TITLE
fix PRNG::get_local not getting the local prng

### DIFF
--- a/src/game_api/prng.cpp
+++ b/src/game_api/prng.cpp
@@ -13,7 +13,7 @@ PRNG& PRNG::get_main()
 PRNG& PRNG::get_local()
 {
     const auto& state = State::get();
-    static PRNG* prng = (PRNG*)((size_t)state.ptr_local() - 0xb0);
+    PRNG* prng = (PRNG*)((size_t)state.ptr_local() - 0xb0);
     return *prng;
 }
 


### PR DESCRIPTION
the prng wasn't set to the current local one due to it being static, returning basically the main prng instead