### PR TITLE
Random UI things

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The binaries will be in `build/bin/Release/`. You can also try the scripts in `.
 
 ```
 --launch_game [path]    launch ../Spel2.exe, path/Spel2.exe, or a specific exe, and load OL with Detours
+--oldflip               launch the game with -oldflip, may improve performance with external windows
 --console               keep console open to debug scripts etc
 --inject                use the old injection method instead of Detours with --launch_game
 --info_dump             output a bunch of game data to 'Spelunky 2/game_data'

--- a/src/game_api/custom_types.cpp
+++ b/src/game_api/custom_types.cpp
@@ -551,7 +551,8 @@ std::span<const ENT_TYPE> get_custom_entity_types(CUSTOM_TYPE type)
             "ENT_TYPE_ITEM_DMCRATE",
             "ENT_TYPE_ITEM_PRESENT",
             "ENT_TYPE_ITEM_GHIST_PRESENT",
-            "ENT_TYPE_ITEM_ALIVE_EMBEDDED_ON_ICE");
+            "ENT_TYPE_ITEM_ALIVE_EMBEDDED_ON_ICE",
+            "ENT_TYPE_ITEM_POT");
     case CUSTOM_TYPE::CONVEYORBELT:
         return make_custom_entity_type_list<CUSTOM_TYPE::CONVEYORBELT>(
             "ENT_TYPE_FLOOR_CONVEYORBELT_LEFT",

--- a/src/game_api/entities_logical.hpp
+++ b/src/game_api/entities_logical.hpp
@@ -30,10 +30,13 @@ class ShootingStarSpawner : public Entity
 class LogicalDoor : public Entity
 {
   public:
+    /// Spawns this entity when not covered by floor. Must be initialized to valid ENT_TYPE before revealed, or crashes the game.
     ENT_TYPE door_type;
-    ENT_TYPE platform_type; // always 37? yeah, that's the floor platform...
+    /// Spawns this entity below when tile below is uncovered. Doesn't spawn anything if it was never covered by floor, unless platform_spawned is set to false. Must be initialized to valid ENT_TYPE before revealed, or crashes the game.
+    ENT_TYPE platform_type;
+    /// Set automatically when not covered by floor.
     bool not_hidden;
-    /// Is set true when you bomb the door, no matter what door, can't be reset
+    /// Set automatically when tile below is not covered by floor. Unset to force the platform to spawn if it was never covered in the first place.
     bool platform_spawned;
     bool unk5;
     bool unk6;

--- a/src/game_api/flags.hpp
+++ b/src/game_api/flags.hpp
@@ -754,5 +754,5 @@ const char* pause_types[]{
     "8: ?",
     "16: ?",
     "32: Ankh (smooth camera, janky audio)",
-    "Freeze on PRE_UPDATE",
+    "Freeze on PRE_UPDATE", // this is not a real state.pause flag, it's only used by ui.cpp for magic
 };

--- a/src/game_api/flags.hpp
+++ b/src/game_api/flags.hpp
@@ -754,4 +754,5 @@ const char* pause_types[]{
     "8: ?",
     "16: ?",
     "32: Ankh (smooth camera, janky audio)",
+    "Freeze on PRE_UPDATE",
 };

--- a/src/game_api/movable.hpp
+++ b/src/game_api/movable.hpp
@@ -163,7 +163,7 @@ class Movable : public Entity
     virtual void on_picked_up_by(Entity* entity_picking_up) = 0;
     virtual void drop(Entity* entity_to_drop) = 0; // also used when throwing
 
-    /// Adds or subtracts the specified amount of money to the movable's (player's) inventory. Shows the calculation animation in the HUD. Important: Updates the collected_money_count in the inventory, but doesn't add any treasure to the following array, which will lead to crashes during the transition, if you don't deal with it. (e.g. set `collected_money_count = collected_money_count - 1` afterwards)
+    /// Adds or subtracts the specified amount of money to the movable's (player's) inventory. Shows the calculation animation in the HUD.
     virtual void add_money(uint32_t money) = 0;
 
     virtual void apply_movement() = 0;              // disable this function and things can't move, some spin in place

--- a/src/game_api/movable.hpp
+++ b/src/game_api/movable.hpp
@@ -163,7 +163,7 @@ class Movable : public Entity
     virtual void on_picked_up_by(Entity* entity_picking_up) = 0;
     virtual void drop(Entity* entity_to_drop) = 0; // also used when throwing
 
-    /// Adds or subtracts the specified amount of money to the movable's (player's) inventory. Shows the calculation animation in the HUD.
+    /// Adds or subtracts the specified amount of money to the movable's (player's) inventory. Shows the calculation animation in the HUD. Important: Updates the collected_money_count in the inventory, but doesn't add any treasure to the following array, which will lead to crashes during the transition, if you don't deal with it. (e.g. set `collected_money_count = collected_money_count - 1` afterwards)
     virtual void add_money(uint32_t money) = 0;
 
     virtual void apply_movement() = 0;              // disable this function and things can't move, some spin in place

--- a/src/game_api/rpc.cpp
+++ b/src/game_api/rpc.cpp
@@ -2074,3 +2074,51 @@ void update_state()
         rf(state);
     }
 }
+
+void set_frametime(std::optional<double> frametime)
+{
+    static size_t offset = 0;
+    if (offset == 0)
+        offset = get_address("engine_frametime");
+    if (offset != 0)
+    {
+        if (frametime.has_value())
+            write_mem_recoverable("engine_frametime", offset, frametime.value(), true);
+        else
+            recover_mem("engine_frametime");
+    }
+}
+
+std::optional<double> get_frametime()
+{
+    static size_t offset = 0;
+    if (offset == 0)
+        offset = get_address("engine_frametime");
+    if (offset != 0)
+        return memory_read<double>(offset);
+    return std::nullopt;
+}
+
+void set_frametime_inactive(std::optional<double> frametime)
+{
+    static size_t offset = 0;
+    if (offset == 0)
+        offset = get_address("engine_frametime") + 0x10;
+    if (offset != 0)
+    {
+        if (frametime.has_value())
+            write_mem_recoverable("engine_frametime_inactive", offset, frametime.value(), true);
+        else
+            recover_mem("engine_frametime_inactive");
+    }
+}
+
+std::optional<double> get_frametime_inactive()
+{
+    static size_t offset = 0;
+    if (offset == 0)
+        offset = get_address("engine_frametime") + 0x10;
+    if (offset != 0)
+        return memory_read<double>(offset);
+    return std::nullopt;
+}

--- a/src/game_api/rpc.cpp
+++ b/src/game_api/rpc.cpp
@@ -2058,3 +2058,19 @@ void set_boss_door_control_enabled(bool enable)
     else
         recover_mem("set_boss_door_control_enabled");
 }
+
+void update_state()
+{
+    static size_t offset = 0;
+    if (offset == 0)
+    {
+        offset = get_address("state_refresh");
+    }
+    if (offset != 0)
+    {
+        auto state = State::get().ptr();
+        typedef void refresh_func(StateMemory*);
+        static refresh_func* rf = (refresh_func*)(offset);
+        rf(state);
+    }
+}

--- a/src/game_api/rpc.hpp
+++ b/src/game_api/rpc.hpp
@@ -144,3 +144,7 @@ void activate_crush_elevator_hack(bool activate);
 void activate_hundun_hack(bool activate);
 void set_boss_door_control_enabled(bool enable);
 void update_state();
+void set_frametime(std::optional<double> frametime);
+std::optional<double> get_frametime();
+void set_frametime_inactive(std::optional<double> frametime);
+std::optional<double> get_frametime_inactive();

--- a/src/game_api/rpc.hpp
+++ b/src/game_api/rpc.hpp
@@ -143,3 +143,4 @@ void activate_tiamat_position_hack(bool activate);
 void activate_crush_elevator_hack(bool activate);
 void activate_hundun_hack(bool activate);
 void set_boss_door_control_enabled(bool enable);
+void update_state();

--- a/src/game_api/script.cpp
+++ b/src/game_api/script.cpp
@@ -128,3 +128,7 @@ void SpelunkyScript::render_options()
 {
     m_Impl->Lock()->render_options();
 }
+std::string SpelunkyScript::execute(std::string code)
+{
+    return m_Impl->Lock()->execute(code);
+}

--- a/src/game_api/script.hpp
+++ b/src/game_api/script.hpp
@@ -98,6 +98,8 @@ class SpelunkyScript
     void draw(ImDrawList* dl);
     void render_options();
 
+    std::string execute(std::string code);
+
   private:
     std::unique_ptr<ScriptImpl> m_Impl;
 };

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -2014,24 +2014,24 @@ end
         return AABB(ax + index * w + 0.02f * f, ay, ax + index * w + w - 0.02f * f, ay - h);
     };
 
+    /// Olmec cutscene moves Olmec and destroys the four floor tiles, so those things never happen if the cutscene is disabled, and Olmec will spawn on even ground. More useful for level gen mods, where the cutscene doesn't make sense. You can also set olmec_cutscene.timer to the last frame (809) to skip to the end, with Olmec in the hole.
     lua["set_olmec_cutscene_enabled"] = set_olmec_cutscene_enabled;
 
-    /// Tiamat cutscene is also responsible for locking the exit door
-    /// So you may need to close it yourself if you still want to be required to kill Tiamat
+    /// Tiamat cutscene is also responsible for locking the exit door, so you may need to close it yourself if you still want Tiamat kill to be required
     lua["set_tiamat_cutscene_enabled"] = set_tiamat_cutscene_enabled;
 
     /// Activate custom variables for position used for detecting the player (normally hardcoded)
-    /// note: because those variables are custom and game does not initiate them, you need to do it yourself for each Tiamat entity, recommending `set_post_entity_spawn`
+    /// note: because those variables are custom and game does not initiate them, you need to do it yourself for each Tiamat entity, recommending set_post_entity_spawn
     /// default game values are: attack_x = 17.5 attack_y = 62.5
     lua["activate_tiamat_position_hack"] = activate_tiamat_position_hack;
 
     /// Activate custom variables for speed and y coordinate limit for crushing elevator
-    /// note: because those variables are custom and game does not initiate them, you need to do it yourself for each CrushElevator entity, recommending `set_post_entity_spawn`
+    /// note: because those variables are custom and game does not initiate them, you need to do it yourself for each CrushElevator entity, recommending set_post_entity_spawn
     /// default game values are: speed = 0.0125, y_limit = 98.5
     lua["activate_crush_elevator_hack"] = activate_crush_elevator_hack;
 
     /// Activate custom variables for y coordinate limit for hundun and spawn of it's heads
-    /// note: because those variables are custom and game does not initiate them, you need to do it yourself for each Hundun entity, recommending `set_post_entity_spawn`
+    /// note: because those variables are custom and game does not initiate them, you need to do it yourself for each Hundun entity, recommending set_post_entity_spawn
     /// default game value are: y_limit = 98.5, rising_speed_x = 0, rising_speed_y = 0.0125, bird_head_spawn_y = 55, snake_head_spawn_y = 71
     lua["activate_hundun_hack"] = activate_hundun_hack;
 
@@ -2039,7 +2039,7 @@ end
     /// This will also prevent game crashing when there is no exit door when they are in level
     lua["set_boss_door_control_enabled"] = set_boss_door_control_enabled;
 
-    /// Run state update manually, i.e. simulate one logic frame
+    /// Run state update manually, i.e. simulate one logic frame. Use in e.g. POST_UPDATE, but be mindful of infinite loops, this will cause another POST_UPDATE. Can even be called thousands of times to simulate minutes of gameplay in a few seconds.
     lua["update_state"] = update_state;
 
     lua.create_named_table("INPUTS", "NONE", 0, "JUMP", 1, "WHIP", 2, "BOMB", 4, "ROPE", 8, "RUN", 16, "DOOR", 32, "MENU", 64, "JOURNAL", 128, "LEFT", 256, "RIGHT", 512, "UP", 1024, "DOWN", 2048);

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -2042,6 +2042,18 @@ end
     /// Run state update manually, i.e. simulate one logic frame. Use in e.g. POST_UPDATE, but be mindful of infinite loops, this will cause another POST_UPDATE. Can even be called thousands of times to simulate minutes of gameplay in a few seconds.
     lua["update_state"] = update_state;
 
+    /// Set engine target frametime (1/framerate, default 1/60). Set to 0 to go as fast as possible. Call without arguments to reset.
+    lua["set_frametime"] = set_frametime;
+
+    /// Get engine target frametime (1/framerate, default 1/60).
+    lua["get_frametime"] = get_frametime;
+
+    /// Set engine target frametime when game is unfocused (1/framerate, default 1/33). Set to 0 to go as fast as possible. Call without arguments to reset.
+    lua["set_frametime_unfocused"] = set_frametime_inactive;
+
+    /// Get engine target frametime when game is unfocused (1/framerate, default 1/33).
+    lua["get_frametime_unfocused"] = get_frametime_inactive;
+
     lua.create_named_table("INPUTS", "NONE", 0, "JUMP", 1, "WHIP", 2, "BOMB", 4, "ROPE", 8, "RUN", 16, "DOOR", 32, "MENU", 64, "JOURNAL", 128, "LEFT", 256, "RIGHT", 512, "UP", 1024, "DOWN", 2048);
 
     lua.create_named_table(

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -2039,6 +2039,9 @@ end
     /// This will also prevent game crashing when there is no exit door when they are in level
     lua["set_boss_door_control_enabled"] = set_boss_door_control_enabled;
 
+    /// Run state update manually, i.e. simulate one logic frame
+    lua["update_state"] = update_state;
+
     lua.create_named_table("INPUTS", "NONE", 0, "JUMP", 1, "WHIP", 2, "BOMB", 4, "ROPE", 8, "RUN", 16, "DOOR", 32, "MENU", 64, "JOURNAL", 128, "LEFT", 256, "RIGHT", 512, "UP", 1024, "DOWN", 2048);
 
     lua.create_named_table(

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -2042,13 +2042,13 @@ end
     /// Run state update manually, i.e. simulate one logic frame. Use in e.g. POST_UPDATE, but be mindful of infinite loops, this will cause another POST_UPDATE. Can even be called thousands of times to simulate minutes of gameplay in a few seconds.
     lua["update_state"] = update_state;
 
-    /// Set engine target frametime (1/framerate, default 1/60). Set to 0 to go as fast as possible. Call without arguments to reset.
+    /// Set engine target frametime (1/framerate, default 1/60). Always capped by your GPU max FPS / VSync. To run the engine faster than rendered FPS, try update_state. Set to 0 to go as fast as possible. Call without arguments to reset.
     lua["set_frametime"] = set_frametime;
 
     /// Get engine target frametime (1/framerate, default 1/60).
     lua["get_frametime"] = get_frametime;
 
-    /// Set engine target frametime when game is unfocused (1/framerate, default 1/33). Set to 0 to go as fast as possible. Call without arguments to reset.
+    /// Set engine target frametime when game is unfocused (1/framerate, default 1/33). Always capped by the engine frametime. Set to 0 to go as fast as possible. Call without arguments to reset.
     lua["set_frametime_unfocused"] = set_frametime_inactive;
 
     /// Get engine target frametime when game is unfocused (1/framerate, default 1/33).

--- a/src/game_api/script/script_impl.cpp
+++ b/src/game_api/script/script_impl.cpp
@@ -207,3 +207,36 @@ const std::filesystem::path& ScriptImpl::get_root_path() const
 {
     return script_folder;
 }
+
+std::string ScriptImpl::execute(std::string str)
+{
+    if (!code.starts_with("return"))
+    {
+        std::string ret = execute_raw("return " + str);
+        if (!ret.starts_with("sol: "))
+        {
+            return ret;
+        }
+    }
+    return execute_raw(std::move(str));
+}
+std::string ScriptImpl::execute_raw(std::string str)
+{
+    try
+    {
+        auto ret = execute_lua(lua, str);
+        if (ret.get_type() == sol::type::nil || ret.get_type() == sol::type::none)
+        {
+            return "";
+        }
+        else
+        {
+            sol::function serpent = lua["serpent"]["block"];
+            return serpent(ret);
+        }
+    }
+    catch (const sol::error& e)
+    {
+        return e.what();
+    }
+}

--- a/src/game_api/script/script_impl.hpp
+++ b/src/game_api/script/script_impl.hpp
@@ -44,4 +44,7 @@ class ScriptImpl : public LockableLuaBackend<ScriptImpl>
     virtual const char* get_path() const override;
     virtual const char* get_root() const override;
     virtual const std::filesystem::path& get_root_path() const override;
+
+    std::string execute(std::string str);
+    std::string execute_raw(std::string str);
 };

--- a/src/game_api/search.cpp
+++ b/src/game_api/search.cpp
@@ -1841,6 +1841,19 @@ std::unordered_map<std::string_view, AddressRule> g_address_rules{
             .function_start(),
     },
     {
+        /* it's a static double, just find something that reads it
+           this+0x08 is clearly some kind of framerate related double, cause it's 60, but don't know what it does
+           this+0x10 is hopefully unfocused frametime for the other function, but maybe it needs own pattern
+        22d12248 00 00 00        double     0.01666666753590107
+                 20 11 11
+                 91 3f */
+        "engine_frametime"sv,
+        PatternCommandBuffer{}
+            .find_after_inst("48 8d 04 0a 48 85 d2 48 0f 44 c2 48 85 c9 48 0f 44 c1 66 0f 28 c8"_gh)
+            .decode_pc(4)
+            .at_exe(),
+    },
+    {
         // Borrowed from Playlunky logger.cpp
         "game_log_function"sv,
         PatternCommandBuffer{}

--- a/src/game_api/window_api.cpp
+++ b/src/game_api/window_api.cpp
@@ -24,6 +24,7 @@ bool detect_wine()
     return true;
 }
 
+UINT g_SyncInterval{1};
 IDXGISwapChain* g_SwapChain{nullptr};
 ID3D11Device* g_Device{nullptr};
 ID3D11DeviceContext* g_Context{nullptr};
@@ -210,6 +211,8 @@ LRESULT CALLBACK hkKeyboard(const int code, const WPARAM wParam, const LPARAM lP
 static bool skip_hkPresent = false;
 HRESULT STDMETHODCALLTYPE hkPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags)
 {
+    SyncInterval = g_SyncInterval;
+
     if (skip_hkPresent)
         return g_OrigSwapChainPresent(pSwapChain, SyncInterval, Flags);
 
@@ -466,6 +469,11 @@ void hide_cursor()
         ImGuiIO& io = ImGui::GetIO();
         io.MouseDrawCursor = false;
     }
+}
+
+void imgui_vsync(bool enable)
+{
+    g_SyncInterval = (UINT)enable;
 }
 
 ID3D11Device* get_device()

--- a/src/game_api/window_api.hpp
+++ b/src/game_api/window_api.hpp
@@ -33,5 +33,6 @@ HWND get_window();
 
 void show_cursor();
 void hide_cursor();
+void imgui_vsync(bool enable);
 
 struct ID3D11Device* get_device();

--- a/src/injected/main.cpp
+++ b/src/injected/main.cpp
@@ -99,7 +99,7 @@ void attach_stdout(DWORD pid)
     freopen_s(&stream, "CONOUT$", "w", stdout);
     freopen_s(&stream, "CONOUT$", "w", stderr);
     // freopen_s(&stream, "CONIN$", "r", stdin);
-    INFO("Press Ctrl+C to detach this window from the process.");
+    INFO("Do not close this window or the game will also die. Press Ctrl+C to detach this window from the game process.");
 }
 
 void run()

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -1306,6 +1306,11 @@ std::string spawned_type()
 
 int32_t spawn_entityitem(EntityItem to_spawn, bool s, bool set_last = true)
 {
+    static const ENT_TYPE also_snap[] = {
+        to_id("ENT_TYPE_LOGICAL_DOOR"),
+        to_id("ENT_TYPE_LOGICAL_BLACKMARKET_DOOR"),
+        to_id("ENT_TYPE_LOGICAL_PLATFORM_SPAWNER"),
+    };
     bool flip = g_vx < -0.04f;
     std::pair<float, float> cpos = UI::click_position(g_x, g_y);
     if (to_spawn.name.find("ENT_TYPE_CHAR") != std::string::npos)
@@ -1332,7 +1337,11 @@ int32_t spawn_entityitem(EntityItem to_spawn, bool s, bool set_last = true)
     else if (to_spawn.name.find("ENT_TYPE_LIQUID") == std::string::npos)
     {
         bool snap = options["snap_to_grid"];
-        if (to_spawn.name.find("ENT_TYPE_FLOOR") != std::string::npos)
+        if (std::find(std::begin(also_snap), std::end(also_snap), to_spawn.id) != std::end(also_snap))
+        {
+            snap = true;
+        }
+        else if (to_spawn.name.find("ENT_TYPE_FLOOR") != std::string::npos)
         {
             snap = true;
             g_vx = 0;
@@ -1383,11 +1392,17 @@ int32_t spawn_entityitem(EntityItem to_spawn, bool s, bool set_last = true)
                 callbacks.push_back(cb);
             }
         }
-        else if (flip)
+        if (flip)
         {
             auto ent = get_entity_ptr(spawned);
             if (ent)
                 ent->flags |= (1U << 16);
+        }
+        if (to_spawn.id == also_snap[0])
+        {
+            auto ent = get_entity_ptr(spawned)->as<LogicalDoor>();
+            ent->door_type = to_id("ENT_TYPE_FLOOR_DOOR_LAYER");
+            ent->platform_type = to_id("ENT_TYPE_FLOOR_DOOR_PLATFORM");
         }
         if (!lock_entity && set_last)
             g_last_id = spawned;

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -294,7 +294,7 @@ std::string fontfile = "";
 std::vector<float> fontsize = {14.0f, 32.0f, 72.0f};
 
 [[maybe_unused]] const char s8_zero = 0, s8_one = 1, s8_min = -128, s8_max = 127;
-[[maybe_unused]] const ImU8 u8_zero = 0, u8_one = 1, u8_min = 0, u8_max = 255, u8_four = 4, u8_seven = 7, u8_seventeen = 17, u8_draw_depth_max = 53;
+[[maybe_unused]] const ImU8 u8_zero = 0, u8_one = 1, u8_min = 0, u8_max = 255, u8_four = 4, u8_seven = 7, u8_seventeen = 17, u8_draw_depth_max = 52, u8_shader_max = 36;
 [[maybe_unused]] const short s16_zero = 0, s16_one = 1, s16_min = -32768, s16_max = 32767;
 [[maybe_unused]] const ImU16 u16_zero = 0, u16_one = 1, u16_min = 0, u16_max = 65535;
 [[maybe_unused]] const ImS32 s32_zero = 0, s32_one = 1, s32_min = INT_MIN / 2, s32_max = INT_MAX / 2, s32_hi_a = INT_MAX / 2 - 100, s32_hi_b = INT_MAX / 2;
@@ -7009,7 +7009,8 @@ void render_entity_props(int uid, bool detached = false)
         uint8_t draw_depth = entity->draw_depth;
         if (ImGui::DragScalar("Draw depth##EntityDrawDepth", ImGuiDataType_U8, &draw_depth, 0.2f, &u8_zero, &u8_draw_depth_max))
             entity->set_draw_depth(draw_depth);
-
+        if (entity->rendering_info)
+            ImGui::DragScalar("Shader##EntityShader", ImGuiDataType_U8, &entity->rendering_info->shader, 0.2f, &u8_zero, &u8_shader_max);
         ImGui::DragScalar("Animation frame##EntityAnimationFrame", ImGuiDataType_U16, &entity->animation_frame, 0.2f, &u16_zero, &u16_max);
         ImGui::InputText(fmt::format("Texture: {}##EntityTexture", textureid).c_str(), &texture, ImGuiInputTextFlags_ReadOnly);
         // ImGui::InputText("Texture path##EntityTexturePath", &texturepath, ImGuiInputTextFlags_ReadOnly);

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -6927,6 +6927,20 @@ void render_entity_props(int uid, bool detached = false)
             ImGui::SameLine();
             ImGui::Text("%s", theme_name(target->theme));
         }
+        else if (entity_type == to_id("ENT_TYPE_LOGICAL_DOOR"))
+        {
+            auto door = entity->as<LogicalDoor>();
+            ImGui::Text("Door type:");
+            ImGui::InputInt("##LogicalDoorDoor", (int*)&door->door_type, 1, 10);
+            ImGui::SameLine();
+            ImGui::Text("%s", entity_names[door->door_type].c_str());
+            ImGui::Text("Platform type:");
+            ImGui::InputInt("##LogicalDoorPlatform", (int*)&door->platform_type, 1, 10);
+            ImGui::SameLine();
+            ImGui::Text("%s", entity_names[door->platform_type].c_str());
+            ImGui::Checkbox("Door spawned##LogicalDoorSpawned", &door->not_hidden);
+            ImGui::Checkbox("Platform spawned##LogicalDoorPlatformSpawned", &door->platform_spawned);
+        }
         else if (entity->type->search_flags & 0x7) // PLYAER, MOUNT, MONSTER
         {
             auto entity_pow = entity->as<PowerupCapable>();

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -348,7 +348,8 @@ std::map<std::string, bool> options = {
     {"hd_cursor", true},
     {"inverted", false},
     {"borders", false},
-    {"console_alt_keys", false}};
+    {"console_alt_keys", false},
+    {"vsync", true}};
 
 bool g_speedhack_hooked = false;
 float g_speedhack_multiplier = 1.0;
@@ -1042,6 +1043,7 @@ void load_config(std::string file)
     }
     ImGui::GetIO().ConfigDockingWithShift = options["docking_with_shift"];
     g_Console->set_alt_keys(options["console_alt_keys"]);
+    imgui_vsync(options["vsync"]);
     save_config(file);
 }
 
@@ -5446,7 +5448,11 @@ void render_options()
             else
                 ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_ViewportsEnable;
         }
-        tooltip("Allow dragging tools outside the main game window, to different monitor etc.");
+        tooltip("Allow dragging tools outside the main game window, to different monitor etc.\nMay work smoother with the -oldflip game command line switch.");
+
+        if (ImGui::Checkbox("Enable vsync", &options["vsync"]))
+            imgui_vsync(options["vsync"]);
+        tooltip("Disabling game vsync may affect performance with external windows,\nfor better or worse.");
 
         if (ImGui::Checkbox("Docking only while holding Shift", &options["docking_with_shift"]))
         {

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -3997,7 +3997,7 @@ void render_grid(ImColor gridcolor = ImColor(1.0f, 1.0f, 1.0f, 0.2f))
     {
         for (unsigned int y = 0; y < g_state->h; ++y)
         {
-            auto room_temp = UI::get_room_template(x, y, g_state->camera_layer);
+            auto room_temp = UI::get_room_template(x, y, peek_layer ? g_state->camera_layer ^ 1 : g_state->camera_layer);
             if (room_temp.has_value())
             {
                 auto room_name = UI::get_room_template_name(room_temp.value());
@@ -6778,7 +6778,7 @@ void render_entity_props(int uid, bool detached = false)
             ImGui::InputFloat("Absolute X##EntityAbsoluteX", &entity->abs_x, 0.2f, 1.0f);
             ImGui::InputFloat("Absolute Y##EntityAbsoluteY", &entity->abs_y, 0.2f, 1.0f);
             ImGui::InputFloat("Velocity X##EntityVelocityX", &movable->velocityx, 0.2f, 1.0f);
-            ImGui::InputFloat("Velocity y##EntityVelocityY", &movable->velocityy, 0.2f, 1.0f);
+            ImGui::InputFloat("Velocity Y##EntityVelocityY", &movable->velocityy, 0.2f, 1.0f);
         }
         ImGui::InputFloat("Angle##EntityAngle", &entity->angle, 0.2f, 1.0f);
         if (is_movable)

--- a/src/injector/main.cpp
+++ b/src/injector/main.cpp
@@ -360,11 +360,15 @@ bool inject_search(fs::path overlunky_path)
     return false;
 }
 
-bool launch(fs::path exe_path, fs::path overlunky_path, bool& do_inject)
+bool launch(fs::path exe_path, fs::path overlunky_path, bool& do_inject, bool& oldflip)
 {
     auto exe_dir = fs::canonical(exe_path).parent_path();
     auto cwd = fs::current_path();
     g_exe = exe_path.filename().string();
+
+    std::string cmdline{"Spel2.exe"};
+    if (oldflip)
+        cmdline = cmdline + " -oldflip";
 
     char dll_path[MAX_PATH] = {};
     sprintf_s(dll_path, MAX_PATH, "%s", overlunky_path.string().c_str());
@@ -400,14 +404,14 @@ bool launch(fs::path exe_path, fs::path overlunky_path, bool& do_inject)
     STARTUPINFOA si{};
     si.cb = sizeof(STARTUPINFO);
 
-    if (!do_inject && DetourCreateProcessWithDlls(NULL, (LPSTR)exe_path.string().c_str(), NULL, NULL, TRUE, CREATE_DEFAULT_ERROR_MODE, (LPVOID)child_env.c_str(), exe_dir.string().c_str(), &si, &pi, 1, dll_paths, NULL))
+    if (!do_inject && DetourCreateProcessWithDlls((LPSTR)exe_path.string().c_str(), (LPSTR)cmdline.c_str(), NULL, NULL, TRUE, CREATE_DEFAULT_ERROR_MODE, (LPVOID)child_env.c_str(), exe_dir.string().c_str(), &si, &pi, 1, dll_paths, NULL))
     {
         INFO("Game launched with DLL");
         wait();
         CloseHandle(pi.hThread);
         return true;
     }
-    else if (CreateProcess((LPSTR)exe_path.string().c_str(), NULL, NULL, NULL, TRUE, 0, (LPVOID)child_env.c_str(), exe_dir.string().c_str(), &si, &pi))
+    else if (CreateProcess((LPSTR)exe_path.string().c_str(), (LPSTR)cmdline.c_str(), NULL, NULL, TRUE, 0, (LPVOID)child_env.c_str(), exe_dir.string().c_str(), &si, &pi))
     {
         auto proc = Process{pi.hProcess, {g_exe, pi.dwProcessId}};
         INFO("Game launched, injecting DLL...");
@@ -454,6 +458,7 @@ int main(int argc, char** argv)
         INFO("You can press ENTER to stop searching and try to launch the game from the parent folder.");
         INFO("Command line switches:");
         INFO("  --launch_game [path]    launch ../Spel2.exe, path/Spel2.exe, or a specific exe, and load OL with Detours");
+        INFO("  --oldflip               launch the game with -oldflip, may improve performance with external windows");
         INFO("  --console               keep console open to debug scripts etc");
         INFO("  --inject                use the old injection method instead of Detours with --launch_game");
         INFO("  --info_dump             output a bunch of game data to 'Spelunky 2/game_data'");
@@ -519,6 +524,7 @@ int main(int argc, char** argv)
 
     bool do_inject = GetCmdLineParam<bool>(cmd_line_parser, "inject", false);
     g_console = GetCmdLineParam<bool>(cmd_line_parser, "console", false);
+    bool oldflip = GetCmdLineParam<bool>(cmd_line_parser, "oldflip", false);
     if (info_dump)
     {
         do_inject = true;
@@ -537,7 +543,7 @@ int main(int argc, char** argv)
 
     if (fs::exists(exe))
     {
-        if (launch(exe, overlunky_path, do_inject))
+        if (launch(exe, overlunky_path, do_inject, oldflip))
         {
             FreeConsole();
             return 0;
@@ -547,7 +553,7 @@ int main(int argc, char** argv)
     {
         if (inject_search(overlunky_path))
         {
-            launch(fs::canonical("../Spel2.exe"), overlunky_path, do_inject);
+            launch(fs::canonical("../Spel2.exe"), overlunky_path, do_inject, oldflip);
         }
     }
     FreeConsole();


### PR DESCRIPTION
- Random UI fixes
- Expose `update_state()` to run the game logic really fast, maybe to skip forward in a TAS or double the game speed
- Add `set_frametime()` to change the target engine fps, capped by gpu/monitor/vsync/whatever still

```lua
-- skip hundun rise in a few seconds, simulating everything in between but not wasting time to render it
while state.time_level < 5000 do
  update_state()
end

-- run game at double speed, but keep timer at normal speed
set_callback(function()
  if not no_repeat then
    no_repeat = true
    update_state()
    state.time_level = state.time_level - 1
    state.time_total = state.time_total - 1
    no_repeat = nil
  end
end, ON.POST_UPDATE)

-- run at 50% speed by changing frametime
set_frametime(1/30)

-- don't cap fps when window is unfocused
set_frametime_unfocused(0)
```