### PR TITLE
More patches

### DIFF
--- a/src/game_api/game_patches.cpp
+++ b/src/game_api/game_patches.cpp
@@ -294,3 +294,14 @@ void set_skip_tiamat_cutscene(bool skip)
     else
         recover_mem("set_skip_tiamat_cutscene");
 }
+
+void patch_ushabti_error()
+{
+    // nops MessageBoxA("Number of generated Ushabti statues isn't 100!")
+    static bool once = false;
+    if (once)
+        return;
+    const auto offset = get_address("ushabti_error");
+    write_mem_prot(offset, "\x90\x90\x90\x90\x90\x90"sv, true);
+    once = true;
+}

--- a/src/game_api/game_patches.cpp
+++ b/src/game_api/game_patches.cpp
@@ -258,6 +258,16 @@ void patch_liquid_OOB()
     write_mem_prot(new_code_addr + 6, rel, true);
     write_mem_prot(new_code_addr + 16, rel - 10, true);
 
+    // replace "Ran out of liquids pool!" with jmp out of the main loop, which effectively
+    // fixes the problem of spawning too much liquid, simply removing some old ones when new is spawned
+    {
+        const size_t message_addr = offset - 0x10f;
+        // replace call MessageBoxA with
+        // jmp whatever (after of the main while do-while != 5 loop)
+        // nop
+        write_mem_prot(message_addr, "\xE9\x72\x01\x00\x00\x90"sv, true);
+    }
+
     once = true;
 }
 

--- a/src/game_api/game_patches.hpp
+++ b/src/game_api/game_patches.hpp
@@ -6,3 +6,4 @@ void patch_liquid_OOB();
 void set_skip_olmec_cutscene(bool skip);
 void patch_tiamat_kill_crash();
 void set_skip_tiamat_cutscene(bool skip);
+void patch_ushabti_error();

--- a/src/game_api/search.cpp
+++ b/src/game_api/search.cpp
@@ -2026,6 +2026,14 @@ std::unordered_map<std::string_view, AddressRule> g_address_rules{
             .at_exe()
             .function_start(),
     },
+    {
+        "ushabti_error"sv,
+        // it's one of the few calls to MessageBoxA, nagging about some Ushabti statues
+        PatternCommandBuffer{}
+            .find_inst("4c 89 e8 4c 29 e0 48 3d 20 03 00 00"_gh)
+            .offset(0x21)
+            .at_exe(),
+    },
 };
 std::unordered_map<std::string_view, size_t> g_cached_addresses;
 

--- a/src/game_api/state.cpp
+++ b/src/game_api/state.cpp
@@ -300,6 +300,7 @@ State& State::get()
                 patch_orbs_limit();
                 patch_olmec_kill_crash();
                 patch_liquid_OOB();
+                patch_ushabti_error();
             }
             else
             {


### PR DESCRIPTION
- Patches spawning more than 4400 liquid by simply removing some old stale liquid instead of doing nothing like a Spelunky 2 dev
- Removes the neobab 4-2  error when (Randomizer) accidentally spawns more than 100 ushabti