### PR TITLE
fix spel2.lua function overloads

### DIFF
--- a/docs/game_data/spel2.lua
+++ b/docs/game_data/spel2.lua
@@ -1,4 +1,6 @@
----@diagnostic disable: unused-function,lowercase-global,missing-return,duplicate-doc-alias,duplicate-set-field
+---@meta
+---@diagnostic disable: duplicate-doc-alias
+
 ---@class Meta
 ---@field name string
 ---@field version string

--- a/docs/generate_emmylua.py
+++ b/docs/generate_emmylua.py
@@ -183,7 +183,9 @@ def main():
     gu.setup_stdout("game_data/spel2.lua")
 
     print(
-        """---@diagnostic disable: unused-function,lowercase-global,missing-return,duplicate-doc-alias,duplicate-set-field
+        """---@meta
+---@diagnostic disable: duplicate-doc-alias
+
 ---@class Meta
 ---@field name string
 ---@field version string


### PR DESCRIPTION
Add `---@meta` to spel2.lua, wich indicates the language server that it is a definition file, making the multiple function declarations to work correctly
https://luals.github.io/wiki/annotations/#meta