### PR TITLE
Pause fixes

### DIFF
--- a/docs/game_data/spel2.lua
+++ b/docs/game_data/spel2.lua
@@ -2078,9 +2078,9 @@ do
     ---@field loading integer @Shows the current loading state (0=Not loading, 1=Fadeout, 2=Loading, 3=Fadein). Writing 1 or 2 will trigger a screen load to `screen_next`.
     ---@field quest_flags QUEST_FLAG @32bit flags, can be written to trigger a run reset on next level load etc.
     ---@field presence_flags PRESENCE_FLAG
-    ---@field fadevalue number @Current fade-to-black amount (0.0 = all visible; 1.0 = all black). Manipulated by the loading routine when loading > 0.
-    ---@field fadeout integer @Amount of frames the fadeout should last when loading
-    ---@field fadein integer @Amount of frames the fadein should last when loading
+    ---@field fade_value number @Current fade-to-black amount (0.0 = all visible; 1.0 = all black). Manipulated by the loading routine when loading > 0.
+    ---@field fade_timer integer @Remaining frames for fade-in/fade-out when loading. Counts down to 0.
+    ---@field fade_length integer @Total frames for fade-in/fade-out when loading.
     ---@field loading_black_screen_timer integer @if state.loading is 1, this timer counts down to 0 while the screen is black (used after Ouroboros, in credits etc.)
     ---@field saved_dogs integer @Run totals
     ---@field saved_cats integer

--- a/docs/src/includes/_types.md
+++ b/docs/src/includes/_types.md
@@ -2941,9 +2941,9 @@ int | [level_flags](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=lev
 int | [loading](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=loading) | Shows the current loading state (0=Not loading, 1=Fadeout, 2=Loading, 3=Fadein). Writing 1 or 2 will trigger a screen load to `screen_next`.
 [QUEST_FLAG](#QUEST_FLAG) | [quest_flags](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=quest_flags) | 32bit flags, can be written to trigger a run reset on next level load etc.
 [PRESENCE_FLAG](#PRESENCE_FLAG) | [presence_flags](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=presence_flags) | 
-float | [fadevalue](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=fadevalue) | Current fade-to-black amount (0.0 = all visible; 1.0 = all black). Manipulated by the loading routine when loading > 0.
-int | [fadeout](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=fadeout) | Amount of frames the fadeout should last when loading
-int | [fadein](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=fadein) | Amount of frames the fadein should last when loading
+float | [fade_value](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=fade_value) | Current fade-to-black amount (0.0 = all visible; 1.0 = all black). Manipulated by the loading routine when loading > 0.
+int | [fade_timer](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=fade_timer) | Remaining frames for fade-in/fade-out when loading. Counts down to 0.
+int | [fade_length](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=fade_length) | Total frames for fade-in/fade-out when loading.
 int | [loading_black_screen_timer](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=loading_black_screen_timer) | if state.loading is 1, this timer counts down to 0 while the screen is black (used after Ouroboros, in credits etc.)
 int | [saved_dogs](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=saved_dogs) | Run totals
 int | [saved_cats](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=saved_cats) | 

--- a/examples/duat_from_any_altar.lua
+++ b/examples/duat_from_any_altar.lua
@@ -17,8 +17,8 @@ function transition_to_duat()
     state.level_next = 4
     state.theme_next = THEME.DUAT
     state.ingame = 1
-    state.fadeout = 18
-    state.fadein = 18
+    state.fade_timer = 18
+    state.fade_length = 18
     state.loading_black_screen_timer = 0
     state:force_current_theme(THEME.CITY_OF_GOLD) -- this makes it so we "come from" COG, which renders the correct limbo transition
     state.loading = 1

--- a/examples/seed_finder.lua
+++ b/examples/seed_finder.lua
@@ -244,9 +244,9 @@ function stats()
 end
 
 set_callback(function()
-    state.fadeout = 0
-    state.fadein = 0
-    state.fadevalue = 0
+    state.fade_timer = 0
+    state.fade_length = 0
+    state.fade_value = 0
     state.loading_black_screen_timer = 0
 
     if not exports.find then return end
@@ -307,16 +307,16 @@ set_callback(function()
     if test_flag(state.quest_flags, 1) and state.screen_next == SCREEN.LEVEL then
         exports.a, exports.b = get_adventure_seed()
     end
-    state.fadeout = 0
-    state.fadein = 0
-    state.fadevalue = 0
+    state.fade_timer = 0
+    state.fade_length = 0
+    state.fade_value = 0
     state.loading_black_screen_timer = 0
 end, ON.PRE_LOAD_SCREEN)
 
 set_callback(function(ctx)
-    state.fadeout = 0
-    state.fadein = 0
-    state.fadevalue = 0
+    state.fade_timer = 0
+    state.fade_length = 0
+    state.fade_value = 0
     state.loading_black_screen_timer = 0
     if not exports.find and not exports.found and not exports.gaveup then
         exports.msg = F"Goal: \"{exports.goal}\"\n\n\n\n"

--- a/examples/tas_controls.lua
+++ b/examples/tas_controls.lua
@@ -63,15 +63,15 @@ set_callback(function()
         zoom(control.zoom)
     end
     if control.fade then
-        state.fadevalue = 0
-        state.fadeout = 0
-        state.fadein = 0
+        state.fade_value = 0
+        state.fade_timer = 0
+        state.fade_length = 0
         state.loading_black_screen_timer = 0
     end
-    if control.level and state.loading == 3 and ((not control.fade and state.fadeout == 1) or control.fade) then
+    if control.level and state.loading == 3 and ((not control.fade and state.fade_timer == 1) or control.fade) then
         control.paused = true
         control.skip = false
-        state.fadevalue = 0
+        state.fade_value = 0
         state.loading = 0
     end
     if control.paused and control.skip then

--- a/examples/tas_test.lua
+++ b/examples/tas_test.lua
@@ -142,7 +142,7 @@ end, 1)
 
 set_callback(function()
     if options.turbo then
-        state.fadeout = 0
-        state.fadein = 0
+        state.fade_timer = 0
+        state.fade_length = 0
     end
 end, ON.LOADING)

--- a/examples/tas_tool.lua
+++ b/examples/tas_tool.lua
@@ -515,9 +515,9 @@ end, 1)]]
 
 set_callback(function()
     if turbo then
-        state.fadeout = 0
-        state.fadein = 0
-        state.fadevalue = 0
+        state.fade_timer = 0
+        state.fade_length = 0
+        state.fade_value = 0
     end
 end, ON.LOADING)
 

--- a/src/game_api/script/usertypes/state_lua.cpp
+++ b/src/game_api/script/usertypes/state_lua.cpp
@@ -324,8 +324,11 @@ void register_usertypes(sol::state& lua)
     statememory_type["loading"] = &StateMemory::loading;
     statememory_type["quest_flags"] = &StateMemory::quest_flags;
     statememory_type["presence_flags"] = &StateMemory::presence_flags;
+    statememory_type["fade_value"] = &StateMemory::fade_value;
     statememory_type["fadevalue"] = &StateMemory::fadevalue;
+    statememory_type["fade_timer"] = &StateMemory::fade_timer;
     statememory_type["fadeout"] = &StateMemory::fadeout;
+    statememory_type["fade_length"] = &StateMemory::fade_length;
     statememory_type["fadein"] = &StateMemory::fadein;
     statememory_type["loading_black_screen_timer"] = &StateMemory::loading_black_screen_timer;
     statememory_type["saved_dogs"] = &StateMemory::saved_dogs;

--- a/src/game_api/state.hpp
+++ b/src/game_api/state.hpp
@@ -64,12 +64,27 @@ struct StateMemory
     uint32_t loading;
     /// The global level illumination, very big and bright.
     Illumination* illumination;
-    /// Current fade-to-black amount (0.0 = all visible; 1.0 = all black). Manipulated by the loading routine when loading > 0.
-    float fadevalue;
-    /// Amount of frames the fadeout should last when loading
-    uint32_t fadeout;
-    /// Amount of frames the fadein should last when loading
-    uint32_t fadein;
+    union
+    {
+        /// Current fade-to-black amount (0.0 = all visible; 1.0 = all black). Manipulated by the loading routine when loading > 0.
+        float fade_value;
+        /// NoDoc
+        float fadevalue;
+    };
+    union
+    {
+        /// Remaining frames for fade-in/fade-out when loading. Counts down to 0.
+        uint32_t fade_timer;
+        /// NoDoc
+        uint32_t fadeout;
+    };
+    union
+    {
+        /// Total frames for fade-in/fade-out when loading.
+        uint32_t fade_length;
+        /// NoDoc
+        uint32_t fadein;
+    };
     /// if state.loading is 1, this timer counts down to 0 while the screen is black (used after Ouroboros, in credits etc.)
     uint32_t loading_black_screen_timer;
     /// Is 1 when you in a game, is set to 0 or 1 in main menu, can't be trusted there, normally in a level is 1 unless you go to the options

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -9783,12 +9783,6 @@ void update_bucket()
     g_bucket->overlunky->selected_uid = g_last_id;
     g_bucket->overlunky->selected_uids = g_selected_ids;
     g_bucket->overlunky->keys = keys;
-    for (auto [k, v] : options)
-    {
-        g_bucket->overlunky->options[k] = options[k];
-    }
-    g_bucket->overlunky->options["pause_type"] = g_pause_type;
-    g_bucket->overlunky->options["paused"] = paused;
 
     for (auto [k, v] : g_bucket->overlunky->set_options)
     {
@@ -9870,6 +9864,13 @@ void update_bucket()
         }
     }
     g_bucket->overlunky->set_options.clear();
+
+    for (auto [k, v] : options)
+    {
+        g_bucket->overlunky->options[k] = options[k];
+    }
+    g_bucket->overlunky->options["pause_type"] = g_pause_type;
+    g_bucket->overlunky->options["paused"] = paused;
 }
 
 void post_draw()

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -9338,10 +9338,9 @@ end
 
 function not_loading()
     local ret = state.loading > 0
-        or state.fade_value > 0
         or (state.screen == SCREEN.MENU and game_manager.screen_menu.menu_text_opacity < 1)
         or (state.screen == SCREEN.CHARACTER_SELECT and (state.screen_character_select.topleft_woodpanel_esc_slidein_timer == 0 or state.screen_character_select.start_pressed))
-    if state.loading == 3 and state.fade_value < 0.03 then
+    if (state.loading == 3 and state.fade_timer == 1) or (state.loading == 1 and state.fade_timer == state.fade_length) then
         ret = false
     end
     return not ret

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -9338,10 +9338,10 @@ end
 
 function not_loading()
     local ret = state.loading > 0
-        or state.fadevalue > 0
+        or state.fade_value > 0
         or (state.screen == SCREEN.MENU and game_manager.screen_menu.menu_text_opacity < 1)
         or (state.screen == SCREEN.CHARACTER_SELECT and (state.screen_character_select.topleft_woodpanel_esc_slidein_timer == 0 or state.screen_character_select.start_pressed))
-    if state.loading == 3 and state.fadevalue < 0.03 then
+    if state.loading == 3 and state.fade_value < 0.03 then
         ret = false
     end
     return not ret
@@ -9486,8 +9486,8 @@ set_callback(clear_hooks, ON.SCRIPT_DISABLE)
     add_ui_script("level_size", false, "");
     add_ui_script("skip_fades", options["skip_fades"], R"(
 set_callback(function()
-    state.fadeout = 0
-    state.fadevalue = 0
+    state.fade_timer = 0
+    state.fade_value = 0
 end, ON.PRE_UPDATE))");
 }
 


### PR DESCRIPTION
This PR fixes a few issues loosely related to the OL pause system:

- Improves StateMemory fade variable names and documentation.
- Fixes OL freeze pauses to consistently stop on the last fade-in frame of a screen.
- Updates OL freeze pauses to also stop on the first fade-out frame of a screen.
- Fixes a bug where bucket `options` took an extra render cycle to update after processing `set_options`.