### PR TITLE
Hotkeys and cross tool input fixes

### DIFF
--- a/docs/game_data/spel2.lua
+++ b/docs/game_data/spel2.lua
@@ -1706,13 +1706,16 @@ function get_image_size(path) end
 ---@return number, number
 function mouse_position() end
 ---Returns: [ImGuiIO](https://spelunky-fyi.github.io/overlunky/#ImGuiIO) for raw keyboard, mouse and xinput gamepad stuff.
----
----- Note: The clicked/pressed actions only make sense in `ON.GUIFRAME`.
----- Note: You can use KEY or standard VK keycodes to index `keys` or the other functions.
----- Note: Overlunky/etc will eat all keys it is currently configured to use, your script will only get leftovers.
----- Note: Gamepad is basically [XINPUT_GAMEPAD](https://docs.microsoft.com/en-us/windows/win32/api/xinput/ns-xinput-xinput_gamepad) but variables are renamed and values are normalized to -1.0..1.0 range.
 ---@return ImGuiIO
 function get_io() end
+---Returns unique id >= 0 for the callback to be used in [clear_callback](https://spelunky-fyi.github.io/overlunky/#clear_callback) or -1 if the key could not be registered.
+---Add callback function to be called on a hotkey, using Windows hotkey api. These hotkeys will override all game and UI input and can work even when the game is unfocused. They are by design very intrusive and won't let anything else use the same key combo. Doesn't work well with OL-PL interaction, use ImGuiIO if you need Playlunky hotkeys to react to Overlunky state.
+---The callback signature is nil on_hotkey(KEY key)
+---@param cb fun(key: KEY): nil
+---@param key KEY
+---@param flags HOTKEY_TYPE
+---@return CallbackId
+function set_hotkey(cb, key, flags) end
 ---Force the LUT texture for the given layer (or both) until it is reset.
 ---Pass `nil` in the first parameter to reset
 ---@param texture_id TEXTURE?
@@ -5118,6 +5121,8 @@ function GuiDrawContext:win_pushid(id) end
     ---@field keyshift boolean
     ---@field keyalt boolean
     ---@field keysuper boolean
+    ---@field modifierdown any @modifierdown
+    ---@field keystring any @keystring
     ---@field wantmouse boolean
     ---@field mousepos Vec2
     ---@field mousedown boolean[] @size: 5
@@ -6438,10 +6443,16 @@ function LogicMagmamanSpawn:remove_spawn(ms) end
     ---@field modifiers_block integer @Bitmask of modifier KEYs that will block all game input
     ---@field modifiers_clear_input boolean @Enable to clear affected input when modifiers are held, disable to ignore all input events, i.e. keep held button state as it was before pressing the modifier key
 
+---@class SharedIO
+    ---@field wantkeyboard boolean?
+    ---@field wantmouse boolean?
+
 ---@class Bucket
     ---@field data table<string, any> @You can store arbitrary simple values here in Playlunky to be read in on Overlunky script for example.
     ---@field overlunky Overlunky @Access Overlunky options here, nil if Overlunky is not loaded.
     ---@field pause PauseAPI @PauseAPI is used by Overlunky and can be used to control the Overlunky pause options from scripts. Can be accessed from the global `pause` more easily.
+    ---@field io SharedIO @Shared part of ImGuiIO to block keyboard/mouse input across API instances.
+    ---@field count integer @Number of API instances present
 
 end
 --## Static class functions

--- a/docs/game_data/spel2.lua
+++ b/docs/game_data/spel2.lua
@@ -1705,11 +1705,13 @@ function get_image_size(path) end
 ---Current mouse cursor position in screen coordinates.
 ---@return number, number
 function mouse_position() end
+---@return nil
+function key_name() end
 ---Returns: [ImGuiIO](https://spelunky-fyi.github.io/overlunky/#ImGuiIO) for raw keyboard, mouse and xinput gamepad stuff.
 ---@return ImGuiIO
 function get_io() end
 ---Returns unique id >= 0 for the callback to be used in [clear_callback](https://spelunky-fyi.github.io/overlunky/#clear_callback) or -1 if the key could not be registered.
----Add callback function to be called on a hotkey, using Windows hotkey api. These hotkeys will override all game and UI input and can work even when the game is unfocused. They are by design very intrusive and won't let anything else use the same key combo. Doesn't work well with OL-PL interaction, use ImGuiIO if you need Playlunky hotkeys to react to Overlunky state.
+---Add callback function to be called on a hotkey, using Windows hotkey api. These hotkeys will override all game and UI input and can work even when the game is unfocused. They are by design very intrusive and won't let anything else use the same key combo. Can't detect if input is active in another instance, use ImGuiIO if you need Playlunky hotkeys to react to Overlunky input state. Key is a KEY combo (e.g. `KEY.OL_MOD_CTRL | KEY.X`), possibly returned by GuiDrawContext:key_picker. Doesn't work with mouse buttons.
 ---The callback signature is nil on_hotkey(KEY key)
 ---@param cb fun(key: KEY): nil
 ---@param key KEY
@@ -2327,6 +2329,7 @@ do
     ---@field slide_position number
 
 ---@class GameProps
+    ---@field buttons integer[] @size: MAX_PLAYERS @Used for player input and might be used for some menu inputs not found in buttons_menu. You can probably capture and edit this in ON.POST_PROCESS_INPUT. These are raw inputs, without things like autorun applied.
     ---@field input integer[] @size: MAX_PLAYERS @Used for player input and might be used for some menu inputs not found in buttons_menu. You can probably capture and edit this in ON.POST_PROCESS_INPUT. These are raw inputs, without things like autorun applied.
     ---@field input_previous integer[] @size: MAX_PLAYERS
     ---@field input_menu MENU_INPUT @Inputs used to control all the menus, separate from player inputs. You can probably capture and edit this in ON.POST_PROCESS_INPUT
@@ -4013,6 +4016,7 @@ function Movable:generic_update_world(move, sprint_factor, disable_gravity, on_r
     ---@field smoke2 ParticleEmitterInfo
 
 ---@class CookFire : Torch
+    ---@field lit any @&Torch::is_lit
     ---@field emitted_light Illumination
     ---@field particles_smoke ParticleEmitterInfo
     ---@field particles_flames ParticleEmitterInfo
@@ -5010,6 +5014,7 @@ function CustomSound:play(paused, sound_type) end
     ---@field win_section fun(self, title: string, callback: function): nil @Add a collapsing accordion section, put contents in the callback function.
     ---@field win_indent fun(self, width: number): nil @Indent contents, or unindent if negative
     ---@field win_width fun(self, width: number): nil @Sets next item width (width>1: width in pixels, width<0: to the right of window, -1<width<1: fractional, multiply by available window width)
+    ---@field key_picker fun(self, message: string, flags: KEY_TYPE): integer @Returns KEY flags including held OL_MOD modifiers, or -1 before any key has been pressed and released, or mouse button pressed. Also returns -1 before all initially held keys are released before the picker was opened, or if another key picker is already waiting for keys. If a modifier is released, that modifier is returned as an actual keycode (e.g. `KEY.LSHIFT`) while the other held modifiers are returned as `KEY.OL_MOD_...` flags.<br/>Shows a fullscreen key picker with a message, with the accepted input type (keyboard/mouse) filtered by flags. The picker won't show before all previously held keys have been released and other key pickers have returned a valid key.
 local GuiDrawContext = nil
 ---Draws a rectangle on screen from top-left to bottom-right.
 ---@param left number
@@ -5111,8 +5116,7 @@ function GuiDrawContext:win_pushid(id) end
 ---@class ImGuiIO
     ---@field displaysize Vec2
     ---@field framerate number
-    ---@field wantkeyboard boolean
-    ---@field keysdown boolean[] @size: ImGuiKey_COUNT
+    ---@field wantkeyboard any @wantkeyboard
     ---@field keys boolean[] @size: ImGuiKey_COUNT
     ---@field keydown fun(key: number | string): boolean
     ---@field keypressed fun(key: number | string, repeat?: boolean ): boolean
@@ -5122,15 +5126,15 @@ function GuiDrawContext:win_pushid(id) end
     ---@field keyalt boolean
     ---@field keysuper boolean
     ---@field modifierdown any @modifierdown
-    ---@field keystring any @keystring
-    ---@field wantmouse boolean
+    ---@field wantmouse any @wantmouse
     ---@field mousepos Vec2
     ---@field mousedown boolean[] @size: 5
     ---@field mouseclicked boolean[] @size: 5
     ---@field mousedoubleclicked boolean[] @size: 5
+    ---@field mousereleased boolean[] @size: 5
     ---@field mousewheel number
     ---@field gamepad Gamepad
-    ---@field gamepads any @[](unsignedintindex){g_WantUpdateHasGamepad=true;returnget_gamepad(index)/**/;}
+    ---@field gamepads any @[](unsignedintindex){g_WantUpdateHasGamepad=true
     ---@field showcursor boolean
 
 ---@class VanillaRenderContext

--- a/docs/parse_source.py
+++ b/docs/parse_source.py
@@ -670,6 +670,8 @@ def run_parse():
                 if not var:
                     continue
                 var = var.split(",")
+                if len(var) < 2:
+                    continue
                 if var[0] == "sol::base_classes" or var[0] == "sol::no_constructor":
                     continue
                 if "NoDoc" in var[0]:

--- a/docs/src/includes/_enums.md
+++ b/docs/src/includes/_enums.md
@@ -647,6 +647,19 @@ Name | Data | Description
 [A](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=KEY.A) | 65 | 
 ...check [lua_enums.txt](game_data/lua_enums.txt)... |  | 
 
+## KEY_TYPE
+
+
+> Search script examples for [KEY_TYPE](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=KEY_TYPE)
+
+
+
+Name | Data | Description
+---- | ---- | -----------
+[ANY](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=KEY_TYPE.ANY) | KEY_TYPE::ANY | 
+[KEYBOARD](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=KEY_TYPE.KEYBOARD) | KEY_TYPE::KEYBOARD | 
+[MOUSE](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=KEY_TYPE.MOUSE) | KEY_TYPE::MOUSE | 
+
 ## LAYER
 
 

--- a/docs/src/includes/_enums.md
+++ b/docs/src/includes/_enums.md
@@ -455,6 +455,19 @@ Name | Data | Description
 [SMALL_SAD](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=GHOST_BEHAVIOR.SMALL_SAD) | GHOST_BEHAVIOR::SMALL_SAD | 
 [SMALL_HAPPY](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=GHOST_BEHAVIOR.SMALL_HAPPY) | GHOST_BEHAVIOR::SMALL_HAPPY | 
 
+## HOTKEY_TYPE
+
+
+> Search script examples for [HOTKEY_TYPE](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=HOTKEY_TYPE)
+
+
+
+Name | Data | Description
+---- | ---- | -----------
+[NORMAL](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=HOTKEY_TYPE.NORMAL) | HOTKEY_TYPE::NORMAL | Suppressed when the game window is inactive or inputting text in this tool instance (get_io().wantkeyboard == true). Can't detect if OL is in a text input and script is running in PL though. Use [ImGuiIO](#ImGuiIO) if you need to do that.<br/>
+[GLOBAL](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=HOTKEY_TYPE.GLOBAL) | HOTKEY_TYPE::GLOBAL | Enabled even when the game window is inactive and will capture keys even from other programs.<br/>
+[INPUT](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=HOTKEY_TYPE.INPUT) | HOTKEY_TYPE::INPUT | Enabled even when inputting text and will override normal text input keys.<br/>
+
 ## HUNDUNFLAGS
 
 

--- a/docs/src/includes/_globals.md
+++ b/docs/src/includes/_globals.md
@@ -1925,7 +1925,7 @@ Set engine target frametime when game is unfocused (1/framerate, default 1/33). 
 #### [CallbackId](#Aliases) set_hotkey([](function cb, [KEY](#KEY) key, [HOTKEY_TYPE](#HOTKEY_TYPE) flags)
 
 Returns unique id >= 0 for the callback to be used in [clear_callback](#clear_callback) or -1 if the key could not be registered.
-Add callback function to be called on a hotkey, using Windows hotkey api. These hotkeys will override all game and UI input and can work even when the game is unfocused. They are by design very intrusive and won't let anything else use the same key combo. Doesn't work well with OL-PL interaction, use [ImGuiIO](#ImGuiIO) if you need Playlunky hotkeys to react to [Overlunky](#Overlunky) state.
+Add callback function to be called on a hotkey, using Windows hotkey api. These hotkeys will override all game and UI input and can work even when the game is unfocused. They are by design very intrusive and won't let anything else use the same key combo. Can't detect if input is active in another instance, use [ImGuiIO](#ImGuiIO) if you need Playlunky hotkeys to react to [Overlunky](#Overlunky) input state. Key is a [KEY](#KEY) combo (e.g. `KEY.OL_MOD_CTRL | KEY.X`), possibly returned by GuiDrawContext:key_picker. Doesn't work with mouse buttons.
 <br/>The callback signature is nil on_hotkey([KEY](#KEY) key)
 
 ### set_infinite_loop_detection_enabled
@@ -3499,6 +3499,14 @@ Will return the string of currently choosen language
 
 Convert the hash to stringid
 Check [strings00_hashed.str](https://github.com/spelunky-fyi/overlunky/blob/main/docs/game_data/strings00_hashed.str) for the hash values, or extract assets with modlunky and check those.
+
+### key_name
+
+
+> Search script examples for [key_name](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=key_name)
+
+#### nil key_name()
+
 
 ### set_level_string
 

--- a/docs/src/includes/_globals.md
+++ b/docs/src/includes/_globals.md
@@ -1917,6 +1917,17 @@ Set engine target frametime (1/framerate, default 1/60). Always capped by your G
 
 Set engine target frametime when game is unfocused (1/framerate, default 1/33). Always capped by the engine frametime. Set to 0 to go as fast as possible. Call without arguments to reset.
 
+### set_hotkey
+
+
+> Search script examples for [set_hotkey](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=set_hotkey)
+
+#### [CallbackId](#Aliases) set_hotkey([](function cb, [KEY](#KEY) key, [HOTKEY_TYPE](#HOTKEY_TYPE) flags)
+
+Returns unique id >= 0 for the callback to be used in [clear_callback](#clear_callback) or -1 if the key could not be registered.
+Add callback function to be called on a hotkey, using Windows hotkey api. These hotkeys will override all game and UI input and can work even when the game is unfocused. They are by design very intrusive and won't let anything else use the same key combo. Doesn't work well with OL-PL interaction, use [ImGuiIO](#ImGuiIO) if you need Playlunky hotkeys to react to [Overlunky](#Overlunky) state.
+<br/>The callback signature is nil on_hotkey([KEY](#KEY) key)
+
 ### set_infinite_loop_detection_enabled
 
 
@@ -2164,11 +2175,6 @@ Converts (x, y, BUTTON) to [INPUTS](#INPUTS)
 #### [ImGuiIO](#ImGuiIO) get_io()
 
 Returns: [ImGuiIO](#ImGuiIO) for raw keyboard, mouse and xinput gamepad stuff.
-
-- Note: The clicked/pressed actions only make sense in `ON.GUIFRAME`.
-- Note: You can use [KEY](#KEY) or standard VK keycodes to index `keys` or the other functions.
-- Note: [Overlunky](#Overlunky)/etc will eat all keys it is currently configured to use, your script will only get leftovers.
-- Note: [Gamepad](#Gamepad) is basically [XINPUT_GAMEPAD](https://docs.microsoft.com/en-us/windows/win32/api/xinput/ns-xinput-xinput_gamepad) but variables are renamed and values are normalized to -1.0..1.0 range.
 
 ### get_raw_input
 

--- a/docs/src/includes/_types.md
+++ b/docs/src/includes/_types.md
@@ -247,6 +247,7 @@ bool | [win_imagebutton(string label, IMAGE image, float width, float height, fl
 nil | [win_section(string title, function callback)](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=win_section) | Add a collapsing accordion section, put contents in the callback function.
 nil | [win_indent(float width)](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=win_indent) | Indent contents, or unindent if negative
 nil | [win_width(float width)](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=win_width) | Sets next item width (width>1: width in pixels, width<0: to the right of window, -1<width<1: fractional, multiply by available window width)
+int | [key_picker(string message, KEY_TYPE flags)](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=key_picker) | Returns [KEY](#KEY) flags including held OL_MOD modifiers, or -1 before any key has been pressed and released, or mouse button pressed. Also returns -1 before all initially held keys are released before the picker was opened, or if another key picker is already waiting for keys. If a modifier is released, that modifier is returned as an actual keycode (e.g. `KEY.LSHIFT`) while the other held modifiers are returned as `KEY.OL_MOD_...` flags.<br/>Shows a fullscreen key picker with a message, with the accepted input type (keyboard/mouse) filtered by flags. The picker won't show before all previously held keys have been released and other key pickers have returned a valid key.
 
 ### LoadContext
 
@@ -1078,19 +1079,24 @@ float | [ry](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=ry) |
 
 ### ImGuiIO
 
-Used in [get_io](#get_io), also see [set_hotkey](#set_hotkey).
+Used in [get_io](#get_io), also see [set_hotkey](#set_hotkey) and [GuiDrawContext](#GuiDrawContext)::key_picker.
 
-- The clicked/pressed actions only make sense in `ON.GUIFRAME`, but get_io() can be used anywhere for the other parts.
-- You can use [KEY](#KEY) or standard VK keycodes to index `keys` or the other functions.
-- Setting `wantkeyboard` early (e.g. already when `modifierdown(KEY.OL_MOD_CTRL)`) will prevent the game and UI from reacting to your actual combo later (e.g. `keypressed(KEY.OL_MOD_CTRL | KEY.X)`)
+- Functions are static, not class methods expecting `self` (call with `get_io().keydown(key)`, not `:`)
+- The clicked/pressed actions only work in `ON.GUIFRAME` (they are true for one GUIFRAME), but get_io() can be used anywhere for the other parts.
+- You can use `KEY` or other standard virtual keycodes < 0xFF to index `keys[]` or in the functions.
+- You can use chords `KEY.OL_MOD_CTRL | KEY.X` in the keydown/keypressed/keyreleased functions.
+- You can also use mouse buttons (e.g. `KEY.OL_MOUSE_1`) or anything returned by GuiDrawContext:key_picker in the keydown/keypressed/keyreleased functions.
+- A modifier key as a keycode (`keypressed(KEY.LCONTROL)`) is not the same as modifier flags OL_MOD_... `keypressed(KEY.OL_MOD_CTRL)` won't work, `keypressed(KEY.OL_MOD_CTRL | KEY.LSHIFT)` will trigger on "Ctrl+Shift" but not "Shift+Ctrl"
+- All held modifiers must be present in the chord, e.g. `keypressed(KEY.OL_MOD_CTRL | KEY.X)` won't trigger when Ctrl+Shift+X is pressed, `keydown(KEY.Y)` won't trigger when Ctrl+Y is pressed.
+- Most fields are read only, except `wantkeyboard`, `wantmouse` and `showcursor`.
+- Setting `wantkeyboard` early (e.g. already when `modifierdown(KEY.OL_MOD_CTRL | KEY.X)`) will prevent the game and UI from reacting to your actual combo later (e.g. `keypressed(KEY.OL_MOD_CTRL | KEY.X)`)
 - [Gamepad](#Gamepad) is basically [XINPUT_GAMEPAD](https://docs.microsoft.com/en-us/windows/win32/api/xinput/ns-xinput-xinput_gamepad) but variables are renamed and values are normalized to -1.0..1.0 range.
 
 Type | Name | Description
 ---- | ---- | -----------
 [Vec2](#Vec2) | [displaysize](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=displaysize) | 
 float | [framerate](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=framerate) | 
-bool | [wantkeyboard](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=wantkeyboard) | True if anyone else (i.e. some input box, OL hotkey) is already capturing keyboard or reacted to this keypress and you probably shouldn't.<br/>Set this to true every GUIFRAME while you want to capture keyboard and disable UI key bindings and game keys. Won't affect UI or game keys on this frame though, that train has already sailed. Also see [Bucket](#Bucket)::[Overlunky](#Overlunky) for other ways to override key bindings.<br/>Do not set this to false, unless you want the player input to bleed through input fields.<br/> 
-bool | [keysdown[ImGuiKey_COUNT]](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=keysdown) | 
+ | [wantkeyboard](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=wantkeyboard) | True if anyone else (i.e. some input box, OL hotkey) is already capturing keyboard or reacted to this keypress and you probably shouldn't.<br/>Set this to true every GUIFRAME while you want to capture keyboard and disable UI key bindings and game keys. Won't affect UI or game keys on this frame though, that train has already sailed. Also see [Bucket](#Bucket)::[Overlunky](#Overlunky) for other ways to override key bindings.<br/>Do not set this to false, unless you want the player input to bleed through input fields.<br/> 
 bool | [keys[ImGuiKey_COUNT]](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=keys) | ZeroIndexArray<bool> of currently held keys, indexed by [KEY](#KEY) <= 0xFF<br/> 
  | [keydown](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=keydown) | Returns true if key or chord (e.g `KEY.X | KEY.OL_MOD_CTRL`) is down.<br/>bool keydown(KEY keychord)<br/>bool keydown(char key)<br/> 
  | [keypressed](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=keypressed) | Returns true if key or chord (e.g `KEY.X | KEY.OL_MOD_CTRL`) was pressed this GUIFRAME.<br/>bool keypressed(KEY keychord, bool repeat = false)<br/>bool keypressed(char key, bool repeat = false)<br/> 
@@ -1100,12 +1106,12 @@ bool | [keyshift](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=keysh
 bool | [keyalt](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=keyalt) | 
 bool | [keysuper](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=keysuper) | 
  | [modifierdown](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=modifierdown) | bool modifierdown([KEY](#KEY) keychord)<br/>Returns true if modifiers in chord (e.g. `KEY.OL_MOD_CTRL | KEY.OL_MOD_SHIFT | KEY.OL_MOD_ALT`) are down, ignores other keys in chord.<br/> 
- | [keystring](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=keystring) | string keystring([KEY](#KEY) keychord)<br/>Returns human readable string from [KEY](#KEY) (e.g. "Ctrl+X")<br/> 
-bool | [wantmouse](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=wantmouse) | True if anyone else (i.e. hovering some window) is already capturing mouse and you probably shouldn't.<br/>Set this to true if you want to capture mouse and override UI mouse binding.<br/> 
+ | [wantmouse](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=wantmouse) | True if anyone else (i.e. hovering some window) is already capturing mouse and you probably shouldn't.<br/>Set this to true if you want to capture mouse and override UI mouse binding.<br/> 
 [Vec2](#Vec2) | [mousepos](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=mousepos) | 
 bool | [mousedown[5]](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=mousedown) | 
 bool | [mouseclicked[5]](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=mouseclicked) | 
 bool | [mousedoubleclicked[5]](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=mousedoubleclicked) | 
+bool | [mousereleased[5]](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=mousereleased) | 
 float | [mousewheel](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=mousewheel) | 
 [Gamepad](#Gamepad) | [gamepad](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=gamepad) | 
  | [gamepads](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=gamepads) | [Gamepad](#Gamepad) gamepads(int index)<br/>This is the XInput index 1..4, might not be the same as the player slot.<br/> 
@@ -2865,6 +2871,7 @@ array&lt;int, MAX_PLAYERS&gt; | [buttons_movement](https://github.com/spelunky-f
 
 Type | Name | Description
 ---- | ---- | -----------
+array&lt;int, MAX_PLAYERS&gt; | [buttons](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=buttons) | Used for player input and might be used for some menu inputs not found in buttons_menu. You can probably capture and edit this in [ON](#ON).POST_PROCESS_INPUT. These are raw inputs, without things like autorun applied.
 array&lt;int, MAX_PLAYERS&gt; | [input](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=input) | Used for player input and might be used for some menu inputs not found in buttons_menu. You can probably capture and edit this in [ON](#ON).POST_PROCESS_INPUT. These are raw inputs, without things like autorun applied.
 array&lt;int, MAX_PLAYERS&gt; | [input_previous](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=input_previous) | 
 [MENU_INPUT](#MENU_INPUT) | [input_menu](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=input_menu) | Inputs used to control all the menus, separate from player inputs. You can probably capture and edit this in [ON](#ON).POST_PROCESS_INPUT
@@ -6015,6 +6022,7 @@ Derived from [Entity](#Entity) [Movable](#Movable) [Torch](#Torch)
 
 Type | Name | Description
 ---- | ---- | -----------
+ | [lit](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=lit) | 
 [Illumination](#Illumination) | [emitted_light](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=emitted_light) | 
 [ParticleEmitterInfo](#ParticleEmitterInfo) | [particles_smoke](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=particles_smoke) | 
 [ParticleEmitterInfo](#ParticleEmitterInfo) | [particles_flames](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=particles_flames) | 

--- a/examples/imguiio.lua
+++ b/examples/imguiio.lua
@@ -45,15 +45,15 @@ set_callback(function()
 
   -- capture keyboard input from game and ui while holding ctrl + alt
   if iio.modifierdown(KEY.OL_MOD_CTRL | KEY.OL_MOD_ALT) then
-    -- if we set this early, it will unregister the games raw input for the next bit,
+    -- if we set this early, it will unregister the games raw input for the next part,
     -- disabling game keys, and also ui keys
     iio.wantkeyboard = true
   end
 
   -- capture single hotkey combo
   if iio.keypressed(KEY.OL_MOD_CTRL | KEY.OL_MOD_ALT | KEY.A) then
-    print(iio.keystring(KEY.OL_MOD_CTRL | KEY.OL_MOD_ALT | KEY.A))
-    -- this is too late to try to get exclusive input for this key combo, it has already passed through the ui, and it's also too late to disable the rawinput
+    print(key_name(KEY.OL_MOD_CTRL | KEY.OL_MOD_ALT | KEY.A))
+    -- this is too late to try to get exclusive input for this key combo, it has already passed through the ui, and it's also too late to disable the rawinput handle the game uses
     --io.wantkeyboard = true
   end
 end, ON.GUIFRAME)
@@ -91,7 +91,7 @@ set_callback(function()
 end, ON.POST_UPDATE)
 
 -- create some global hotkeys
-function hotkey_handler(key) print(get_io().keystring(key)) end
+function hotkey_handler(key) print(key_name(key)) end
 
 -- will be suppressed by inactive window or active input fields in this tool instance
 set_hotkey(hotkey_handler, KEY.Z | KEY.OL_MOD_CTRL, HOTKEY_TYPE.NORMAL)

--- a/examples/imguiio.lua
+++ b/examples/imguiio.lua
@@ -19,7 +19,7 @@ set_callback(function()
   if iio.mouseclicked[1] then
     local x, y = mouse_position()
     if iio.wantmouse then
-      print("Clicked inside Overlunky window, plz ignore")
+      print("Clicked inside Overlunky window or 'Mouse Controls' is enabled, plz ignore")
     else
       print(F "Clicked {x},{y} and it's fair game")
     end
@@ -104,7 +104,11 @@ set_hotkey(hotkey_handler, KEY.X | KEY.OL_MOD_ALT, HOTKEY_TYPE.GLOBAL | HOTKEY_T
 -- opens the key picker when any key is still unbound,
 -- checks if ui is already capturing input
 -- and tells overlunky to ignore picked keys
-keys = {}
+keys = {
+  first = KEY.OL_MOD_CTRL | KEY.A,
+  second = nil, -- choose with key picker when enabled
+  third = -1,   -- choose with key picker when enabled
+}
 function key_handler(ctx, name)
   if not keys[name] or keys[name] == -1 then
     keys[name] = ctx:key_picker(F "Pick key for: {name}", KEY_TYPE.ANY)
@@ -118,7 +122,9 @@ function key_handler(ctx, name)
         end
       end
     end
-  elseif not get_io().wantkeyboard then
+  elseif not test_mask(keys[name], KEY_TYPE.MOUSE) and not get_io().wantkeyboard then
+    return get_io().keypressed(keys[name])
+  elseif test_mask(keys[name], KEY_TYPE.MOUSE) and not get_io().wantmouse then
     return get_io().keypressed(keys[name])
   end
 end

--- a/examples/imguiio.lua
+++ b/examples/imguiio.lua
@@ -1,21 +1,10 @@
-meta.name = 'Raw input test'
+meta.name = 'ImGuiIO input and hotkeys'
 meta.version = 'WIP'
-meta.description = 'Test raw keyboard, mouse and gamepad input.'
+meta.description = 'Examples on imgui keyboard, mouse and gamepad input, also set_hotkey.'
 meta.author = 'Dregu'
 
-local iio = get_io()
-local prev_keys = ''
-
 set_callback(function()
-  -- Show currently pressed keys. Note: Overlunky will eat all keys configured as hotkeys. Modifiers Ctrl, Alt and Super probably don't even right.
-  local keys = ''
-  for i,v in ipairs(iio.keysdown) do
-    if v then keys = keys .. string.char(i-1) end
-  end
-  if keys ~= prev_keys then
-    print(keys)
-  end
-  prev_keys = keys
+  local iio = get_io()
 
   -- Press S to realize S was pressed, ignoring when inputting text in OL
   if iio.keypressed('S') then
@@ -32,7 +21,7 @@ set_callback(function()
     if iio.wantmouse then
       print("Clicked inside Overlunky window, plz ignore")
     else
-      print(F"Clicked {x},{y} and it's fair game")
+      print(F "Clicked {x},{y} and it's fair game")
     end
   end
 
@@ -40,17 +29,38 @@ set_callback(function()
   if iio.mousewheel ~= 0 and not iio.wantmouse then
     local dir = 'up'
     if iio.mousewheel < 0 then dir = 'down' end
-    print(F'Wheel going {dir}')
+    print(F 'Wheel going {dir}')
   end
 
   -- Draw raw gamepad data if one is connected
   if iio.gamepad.enabled then
     draw_circle_filled(iio.gamepad.rx, iio.gamepad.ry, 0.02, 0x660000ff)
   end
+
+  -- if someone is already using keyboard for input, we probably shouldn't
+  -- also true when OL has a hotkey that matches to this event
+  if iio.wantkeyboard then
+    return
+  end
+
+  -- capture keyboard input from game and ui while holding ctrl + alt
+  if iio.modifierdown(KEY.OL_MOD_CTRL | KEY.OL_MOD_ALT) then
+    -- if we set this early, it will unregister the games raw input for the next bit,
+    -- disabling game keys, and also ui keys
+    iio.wantkeyboard = true
+  end
+
+  -- capture single hotkey combo
+  if iio.keypressed(KEY.OL_MOD_CTRL | KEY.OL_MOD_ALT | KEY.A) then
+    print(iio.keystring(KEY.OL_MOD_CTRL | KEY.OL_MOD_ALT | KEY.A))
+    -- this is too late to try to get exclusive input for this key combo, it has already passed through the ui, and it's also too late to disable the rawinput
+    --io.wantkeyboard = true
+  end
 end, ON.GUIFRAME)
 
 -- XInput Gamepad
 set_callback(function()
+  local iio = get_io()
   if #players < 1 then return end
   if not iio.gamepad.enabled then return end
 
@@ -58,24 +68,33 @@ set_callback(function()
 
   -- Fly around with right stick
   if math.abs(iio.gamepad.rx) > 0.1 then
-    players[1].velocityx = iio.gamepad.rx/5
+    players[1].velocityx = iio.gamepad.rx / 5
     players[1].velocityy = 0.01
     players[1].falling_timer = 0
   end
   if math.abs(iio.gamepad.ry) > 0.1 then
-    players[1].velocityy = iio.gamepad.ry/5
+    players[1].velocityy = iio.gamepad.ry / 5
     players[1].falling_timer = 0
   end
 
   -- Throw bombs when holding triggers
   if iio.gamepad.lt > 0.5 and (get_frame() % 4) == 0 then
-    spawn(ENT_TYPE.ITEM_BOMB, x-0.2, y, l, -1, 0.06)
+    spawn(ENT_TYPE.ITEM_BOMB, x - 0.2, y, l, -1, 0.06)
   end
   if iio.gamepad.rt > 0.5 and (get_frame() % 4) == 0 then
-    spawn(ENT_TYPE.ITEM_BOMB, x+0.2, y, l, 1, 0.06)
+    spawn(ENT_TYPE.ITEM_BOMB, x + 0.2, y, l, 1, 0.06)
   end
 
   -- Check if a button is down
   -- Get your button flags from https://docs.microsoft.com/en-us/windows/win32/api/xinput/ns-xinput-xinput_gamepad#members for now...
   if (iio.gamepad.buttons & 0x100) > 0 then print("Holding L1") end
-end, ON.FRAME)
+end, ON.POST_UPDATE)
+
+-- create some global hotkeys
+function hotkey_handler(key) print(get_io().keystring(key)) end
+
+-- will be suppressed by inactive window or active input fields in this tool instance
+set_hotkey(hotkey_handler, KEY.Z | KEY.OL_MOD_CTRL, HOTKEY_TYPE.NORMAL)
+
+-- won't be suppressed by inactive window or input fields
+set_hotkey(hotkey_handler, KEY.X | KEY.OL_MOD_ALT, HOTKEY_TYPE.GLOBAL | HOTKEY_TYPE.INPUT)

--- a/src/game_api/aliases.hpp
+++ b/src/game_api/aliases.hpp
@@ -46,7 +46,7 @@
                    static_cast<std::underlying_type_t<Enum>>(Rhs)); \
     }
 
-using CallbackId = uint32_t;
+using CallbackId = int32_t;
 using Flags = uint32_t;
 using uColor = uint32_t;
 using SPAWN_TYPE = uint32_t;                  // NoAlias
@@ -80,11 +80,11 @@ enum class HOTKEY_TYPE : int32_t
 };
 ENUM_CLASS_FLAGS(HOTKEY_TYPE);
 
-enum class KEY_TYPE : int8_t
+enum class KEY_TYPE : int32_t
 {
     ANY = 0,
-    KEYBOARD = 1 << 0,
-    MOUSE = 1 << 1,
+    KEYBOARD = 0xFF,
+    MOUSE = 0x400,
 };
 ENUM_CLASS_FLAGS(KEY_TYPE);
 

--- a/src/game_api/aliases.hpp
+++ b/src/game_api/aliases.hpp
@@ -80,6 +80,14 @@ enum class HOTKEY_TYPE : int32_t
 };
 ENUM_CLASS_FLAGS(HOTKEY_TYPE);
 
+enum class KEY_TYPE : int8_t
+{
+    ANY = 0,
+    KEYBOARD = 1 << 0,
+    MOUSE = 1 << 1,
+};
+ENUM_CLASS_FLAGS(KEY_TYPE);
+
 enum class LAYER : int32_t
 {
     FRONT = 0,

--- a/src/game_api/aliases.hpp
+++ b/src/game_api/aliases.hpp
@@ -72,6 +72,14 @@ using RAW_KEY = int8_t; // NoAlias
 
 inline constexpr uint8_t MAX_PLAYERS = 4;
 
+enum class HOTKEY_TYPE : int32_t
+{
+    NORMAL = 0,
+    GLOBAL = 1 << 0,
+    INPUT = 1 << 1,
+};
+ENUM_CLASS_FLAGS(HOTKEY_TYPE);
+
 enum class LAYER : int32_t
 {
     FRONT = 0,

--- a/src/game_api/bucket.cpp
+++ b/src/game_api/bucket.cpp
@@ -17,6 +17,7 @@ Bucket* Bucket::get()
     auto new_bucket = new Bucket();
     write_mem_prot(bucket_offset, new_bucket, true);
     new_bucket->pause_api = new PauseAPI();
+    new_bucket->io = new SharedIO();
     return new_bucket;
 }
 

--- a/src/game_api/bucket.hpp
+++ b/src/game_api/bucket.hpp
@@ -122,6 +122,12 @@ struct PauseAPI
     void post_input();
 };
 
+struct SharedIO
+{
+    std::optional<bool> WantCaptureKeyboard;
+    std::optional<bool> WantCaptureMouse;
+};
+
 class Bucket
 {
   public:
@@ -143,6 +149,8 @@ class Bucket
     bool forward_blocked_events{false};
     // Set to true when the callback was blocked by Overlunky and should also be blocked in Playlunky
     bool blocked_event{false};
+    /// Shared part of ImGuiIO to block keyboard/mouse input across API instances.
+    SharedIO* io{nullptr};
 
   private:
     Bucket() = default;

--- a/src/game_api/bucket.hpp
+++ b/src/game_api/bucket.hpp
@@ -151,6 +151,8 @@ class Bucket
     bool blocked_event{false};
     /// Shared part of ImGuiIO to block keyboard/mouse input across API instances.
     SharedIO* io{nullptr};
+    /// Number of API instances present
+    int count{0};
 
   private:
     Bucket() = default;

--- a/src/game_api/hook_handler.hpp
+++ b/src/game_api/hook_handler.hpp
@@ -10,7 +10,8 @@ enum class CallbackType
     Normal,
     Entity,
     Screen,
-    Theme
+    Theme,
+    HotKey
 };
 
 template <

--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -1996,7 +1996,7 @@ int LuaBackend::register_hotkey(HotKeyCallback cb, HOTKEY_TYPE flags)
 
 void LuaBackend::hotkey_callback(int cb)
 {
-    if (!hotkey_callbacks.contains(cb))
+    if (!get_enabled() || !hotkey_callbacks.contains(cb))
         return;
     hotkey_callbacks[cb].queue++;
 }

--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -33,9 +33,12 @@
 #include "usertypes/level_lua.hpp"          // for PreHandleRoomTilesContext
 #include "usertypes/save_context.hpp"       // for LoadContext, SaveContext
 #include "usertypes/vanilla_render_lua.hpp" // for VanillaRenderContext
+#include "window_api.hpp"                   // for get_window
 
 std::recursive_mutex g_all_backends_mutex;
 std::vector<std::unique_ptr<LuaBackend::ProtectedBackend>> g_all_backends;
+std::unordered_map<int, HotKey> g_hotkeys;
+int g_hotkey_count = 0;
 
 LuaBackend::LuaBackend(SoundManager* sound_mgr, LuaConsole* con)
     : lua{get_lua_vm(sound_mgr), sol::create}, vm{acquire_lua_vm(sound_mgr)}, sound_manager{sound_mgr}, console{con}
@@ -115,6 +118,17 @@ void LuaBackend::clear_all_callbacks()
         g_state->level_gen->data->undefine_extra_spawn(id);
     }
     extra_spawn_callbacks.clear();
+
+    for (auto& [id, callback] : hotkey_callbacks)
+    {
+        if (g_hotkeys.contains(callback.hotkeyid))
+        {
+            if (g_hotkeys[callback.hotkeyid].active)
+                UnregisterHotKey(get_window(), callback.hotkeyid);
+            g_hotkeys.erase(callback.hotkeyid);
+        }
+    }
+    hotkey_callbacks.clear();
 
     HookHandler<Entity, CallbackType::Entity>::clear_all_hooks();
     HookHandler<RenderInfo, CallbackType::Entity>::clear_all_hooks();
@@ -312,6 +326,9 @@ bool LuaBackend::update()
             callbacks.erase(id);
             load_callbacks.erase(id);
             save_callbacks.erase(id);
+            if (hotkey_callbacks.contains(id) && g_hotkeys.contains(hotkey_callbacks[id].hotkeyid) && g_hotkeys[hotkey_callbacks[id].hotkeyid].active)
+                UnregisterHotKey(get_window(), hotkey_callbacks[id].hotkeyid);
+            hotkey_callbacks.erase(id);
 
             std::erase_if(pre_tile_code_callbacks, [id](auto& cb)
                           { return cb.id == id; });
@@ -589,6 +606,22 @@ void LuaBackend::draw(ImDrawList* dl)
                 handle_function<void>(this, callback.func, draw_ctx);
                 clear_current_callback();
                 callback.lastRan = now;
+            }
+        }
+
+        for (auto& [id, callback] : hotkey_callbacks)
+        {
+            if (is_callback_cleared(id))
+                continue;
+
+            auto now = get_frame_count();
+            while (callback.queue > 0)
+            {
+                set_current_callback(-1, id, CallbackType::HotKey);
+                handle_function<void>(this, callback.func, callback.key);
+                clear_current_callback();
+                callback.lastRan = now;
+                callback.queue--;
             }
         }
     }
@@ -1907,6 +1940,75 @@ void LuaBackend::post_load_state(int slot, StateMemory* loaded)
             handle_function<void>(this, callback.func, slot, loaded);
             clear_current_callback();
             callback.lastRan = now;
+        }
+    }
+}
+
+int LuaBackend::register_hotkey(HotKeyCallback cb, bool global)
+{
+    const int OL_KEY_CTRL = 0x100;
+    const int OL_KEY_SHIFT = 0x200;
+    const int OL_KEY_ALT = 0x800;
+
+    int vk = cb.key & 0xff;
+    int mod = 0;
+    if (cb.key & OL_KEY_CTRL)
+        mod |= MOD_CONTROL;
+    if (cb.key & OL_KEY_SHIFT)
+        mod |= MOD_SHIFT;
+    if (cb.key & OL_KEY_ALT)
+        mod |= MOD_ALT;
+
+    int id = g_hotkey_count;
+
+    if (RegisterHotKey(get_window(), id, mod, vk))
+    {
+        cb.hotkeyid = id;
+        auto hotkey = HotKey{mod, vk, this, cbcount, true, global};
+        g_hotkeys[id] = hotkey;
+        hotkey_callbacks[cbcount] = cb;
+        g_hotkey_count++;
+        return cbcount++;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+void LuaBackend::hotkey_callback(int cb)
+{
+    if (!hotkey_callbacks.contains(cb))
+        return;
+    hotkey_callbacks[cb].queue++;
+}
+
+void LuaBackend::wm_hotkey(int keyid)
+{
+    if (!g_hotkeys.contains(keyid))
+        return;
+    g_hotkeys[keyid].backend->hotkey_callback(g_hotkeys[keyid].cb);
+}
+
+void LuaBackend::wm_activate(bool active)
+{
+    for (auto& [id, hotkey] : g_hotkeys)
+    {
+        if (active)
+        {
+            if (!hotkey.active)
+            {
+                RegisterHotKey(get_window(), id, hotkey.mod, hotkey.key);
+                hotkey.active = true;
+            }
+        }
+        else
+        {
+            if (!hotkey.global && hotkey.active)
+            {
+                UnregisterHotKey(get_window(), id);
+                hotkey.active = false;
+            }
         }
     }
 }

--- a/src/game_api/script/lua_backend.hpp
+++ b/src/game_api/script/lua_backend.hpp
@@ -460,7 +460,7 @@ class LuaBackend
     void on_post(ON event);
 
     void hotkey_callback(int cb);
-    int register_hotkey(HotKeyCallback cb, bool global);
+    int register_hotkey(HotKeyCallback cb, HOTKEY_TYPE flags);
     static void wm_activate(bool active);
     static void wm_hotkey(int keyid);
 };
@@ -485,5 +485,6 @@ struct HotKey
     LuaBackend* backend;
     int cb;
     bool active;
-    bool global;
+    HOTKEY_TYPE flags;
+    HOTKEY_TYPE suppressflags;
 };

--- a/src/game_api/script/lua_backend.hpp
+++ b/src/game_api/script/lua_backend.hpp
@@ -270,6 +270,15 @@ struct SavedUserData
     std::unordered_map<uint32_t, sol::object> powerups;
 };
 
+struct HotKeyCallback
+{
+    sol::function func;
+    KEY key;
+    int lastRan;
+    int queue;
+    int hotkeyid;
+};
+
 struct StateMemory;
 class SoundManager;
 class LuaConsole;
@@ -303,6 +312,7 @@ class LuaBackend
     std::unordered_map<int, ScreenCallback> callbacks;
     std::unordered_map<int, ScreenCallback> load_callbacks;
     std::unordered_map<int, ScreenCallback> save_callbacks;
+    std::unordered_map<int, HotKeyCallback> hotkey_callbacks;
     std::vector<std::uint32_t> vanilla_sound_callbacks;
     std::vector<LevelGenCallback> pre_tile_code_callbacks;
     std::vector<LevelGenCallback> post_tile_code_callbacks;
@@ -448,6 +458,11 @@ class LuaBackend
     void load_user_data();
     bool on_pre(ON event);
     void on_post(ON event);
+
+    void hotkey_callback(int cb);
+    int register_hotkey(HotKeyCallback cb, bool global);
+    static void wm_activate(bool active);
+    static void wm_hotkey(int keyid);
 };
 
 template <class Inheriting>
@@ -461,4 +476,14 @@ class LockableLuaBackend : public LuaBackend
     {
         return self->LockAs<Inheriting>();
     }
+};
+
+struct HotKey
+{
+    int mod;
+    int key;
+    LuaBackend* backend;
+    int cb;
+    bool active;
+    bool global;
 };

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -546,13 +546,23 @@ end
             }
         });
     /// Returns unique id for the callback to be used in [clear_callback](#clear_callback).
-    /// Add callback function to be called on a hotkey, using Windows hotkey api. These hotkeys will override all game and UI input and can work even when the game is unfocused.
+    /// Add callback function to be called on a hotkey, using Windows hotkey api. These hotkeys will override all game and UI input and can work even when the game is unfocused. They are by design very intrusive and won't let anything else use the same key combo. Doesn't work well with OL-PL interaction, use ImGuiIO if you need Playlunky hotkeys to react to Overlunky state.
     /// <br/>The callback signature is nil on_hotkey(KEY key)
-    lua["set_hotkey"] = sol::overload([](sol::function cb, KEY key, bool global = false) -> CallbackId
+    lua["set_hotkey"] = sol::overload([](sol::function cb, KEY key, HOTKEY_TYPE flags) -> CallbackId
                                       {
         auto backend = LuaBackend::get_calling_backend();
         auto luaCb = HotKeyCallback{cb, key, -1, false, 0};
-        return backend->register_hotkey(luaCb, global); });
+        return backend->register_hotkey(luaCb, flags); });
+
+    lua.create_named_table("HOTKEY_TYPE", "NORMAL", HOTKEY_TYPE::NORMAL, "GLOBAL", HOTKEY_TYPE::GLOBAL, "INPUT", HOTKEY_TYPE::INPUT);
+    /* HOTKEY_TYPE
+    // NORMAL
+    // Suppressed when the game window is inactive or inputting text in this tool instance (get_io().wantkeyboard == true). Can't detect if OL is in a text input and script is running in PL though. Use ImGuiIO if you need to do that.
+    // GLOBAL
+    // Enabled even when the game window is inactive and will capture keys even from other programs.
+    // INPUT
+    // Enabled even when inputting text and will override normal text input keys.
+    */
 
     /// Table of options set in the UI, added with the [register_option_functions](#Option-functions), but `nil` before any options are registered. You can also write your own options in here or override values defined in the register functions/UI before or after they are registered. Check the examples for many different use cases and saving options to disk.
     // lua["options"] = lua.create_named_table("options");

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -545,6 +545,14 @@ end
                 break;
             }
         });
+    /// Returns unique id for the callback to be used in [clear_callback](#clear_callback).
+    /// Add callback function to be called on a hotkey, using Windows hotkey api. These hotkeys will override all game and UI input and can work even when the game is unfocused.
+    /// <br/>The callback signature is nil on_hotkey(KEY key)
+    lua["set_hotkey"] = sol::overload([](sol::function cb, KEY key, bool global = false) -> CallbackId
+                                      {
+        auto backend = LuaBackend::get_calling_backend();
+        auto luaCb = HotKeyCallback{cb, key, -1, false, 0};
+        return backend->register_hotkey(luaCb, global); });
 
     /// Table of options set in the UI, added with the [register_option_functions](#Option-functions), but `nil` before any options are registered. You can also write your own options in here or override values defined in the register functions/UI before or after they are registered. Check the examples for many different use cases and saving options to disk.
     // lua["options"] = lua.create_named_table("options");

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -528,6 +528,7 @@ end
             switch (caller.type)
             {
             case CallbackType::Normal:
+            case CallbackType::HotKey:
                 backend->clear_callbacks.push_back(caller.id);
                 break;
             case CallbackType::Entity:

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -545,14 +545,6 @@ end
                 break;
             }
         });
-    /// Returns unique id for the callback to be used in [clear_callback](#clear_callback).
-    /// Add callback function to be called on a hotkey, using Windows hotkey api. These hotkeys will override all game and UI input and can work even when the game is unfocused. They are by design very intrusive and won't let anything else use the same key combo. Doesn't work well with OL-PL interaction, use ImGuiIO if you need Playlunky hotkeys to react to Overlunky state.
-    /// <br/>The callback signature is nil on_hotkey(KEY key)
-    lua["set_hotkey"] = sol::overload([](sol::function cb, KEY key, HOTKEY_TYPE flags) -> CallbackId
-                                      {
-        auto backend = LuaBackend::get_calling_backend();
-        auto luaCb = HotKeyCallback{cb, key, -1, false, 0};
-        return backend->register_hotkey(luaCb, flags); });
 
     lua.create_named_table("HOTKEY_TYPE", "NORMAL", HOTKEY_TYPE::NORMAL, "GLOBAL", HOTKEY_TYPE::GLOBAL, "INPUT", HOTKEY_TYPE::INPUT);
     /* HOTKEY_TYPE

--- a/src/game_api/script/usertypes/bucket_lua.cpp
+++ b/src/game_api/script/usertypes/bucket_lua.cpp
@@ -65,6 +65,7 @@ void register_usertypes(sol::state& lua)
     bucket_type["overlunky"] = sol::readonly(&Bucket::overlunky);
     bucket_type["pause"] = &Bucket::pause_api;
     bucket_type["io"] = &Bucket::io;
+    bucket_type["count"] = sol::readonly(&Bucket::count);
 
     /// Returns the Bucket of data stored in shared memory between Overlunky and Playlunky
     // lua["get_bucket"] = []() -> Bucket*

--- a/src/game_api/script/usertypes/bucket_lua.cpp
+++ b/src/game_api/script/usertypes/bucket_lua.cpp
@@ -55,11 +55,16 @@ void register_usertypes(sol::state& lua)
     /// NoDoc
     lua["pause"][sol::metatable_key]["__call"] = &PauseAPI::set_paused;
 
+    auto sharedio_type = lua.new_usertype<SharedIO>("SharedIO", sol::no_constructor);
+    sharedio_type["wantkeyboard"] = &SharedIO::WantCaptureKeyboard;
+    sharedio_type["wantmouse"] = &SharedIO::WantCaptureMouse;
+
     /// Shared memory structure used for Playlunky-Overlunky interoperability
     auto bucket_type = lua.new_usertype<Bucket>("Bucket", sol::no_constructor);
     bucket_type["data"] = &Bucket::data;
     bucket_type["overlunky"] = sol::readonly(&Bucket::overlunky);
     bucket_type["pause"] = &Bucket::pause_api;
+    bucket_type["io"] = &Bucket::io;
 
     /// Returns the Bucket of data stored in shared memory between Overlunky and Playlunky
     // lua["get_bucket"] = []() -> Bucket*

--- a/src/game_api/script/usertypes/gui_lua.cpp
+++ b/src/game_api/script/usertypes/gui_lua.cpp
@@ -20,6 +20,7 @@
 #include <utility>          // for max, min, pair, get, make_pair
 #include <xinput.h>         // for XINPUT_STATE, XINPUT_CAPABILITIES
 
+#include "bucket.hpp"
 #include "file_api.hpp"                   // for create_d3d11_texture_from_file
 #include "math.hpp"                       // for Vec2
 #include "script.hpp"                     // for ScriptMessage, ScriptImage
@@ -818,7 +819,13 @@ void register_usertypes(sol::state& lua)
         "framerate",
         &ImGuiIO::Framerate,
         "wantkeyboard",
-        &ImGuiIO::WantCaptureKeyboard,
+        sol::property([](ImGuiIO& io) -> bool
+                      { return io.WantCaptureKeyboard; },
+                      [](ImGuiIO& io, bool want)
+                      {
+                          Bucket::get()->io->WantCaptureKeyboard = want;
+                          io.WantCaptureKeyboard = want;
+                      }),
         /// NoDoc
         "keysdown",
         sol::property([](ImGuiIO& io)
@@ -841,7 +848,13 @@ void register_usertypes(sol::state& lua)
         "keysuper",
         &ImGuiIO::KeySuper,
         "wantmouse",
-        &ImGuiIO::WantCaptureMouse,
+        sol::property([](ImGuiIO& io) -> bool
+                      { return io.WantCaptureMouse; },
+                      [](ImGuiIO& io, bool want)
+                      {
+                          Bucket::get()->io->WantCaptureMouse = want;
+                          io.WantCaptureMouse = want;
+                      }),
         "mousepos",
         sol::property([](ImGuiIO& io) -> Vec2
                       { return Vec2(io.MousePos) /**/; }),

--- a/src/game_api/script/usertypes/gui_lua.hpp
+++ b/src/game_api/script/usertypes/gui_lua.hpp
@@ -119,6 +119,9 @@ class GuiDrawContext
     void win_indent(float width);
     /// Sets next item width (width>1: width in pixels, width<0: to the right of window, -1<width<1: fractional, multiply by available window width)
     void win_width(float width);
+    /// Returns KEY flags including held OL_MOD modifiers, or -1 before any key has been pressed and released, or mouse button pressed. Also returns -1 before all initially held keys are released before the picker was opened, or if another key picker is already waiting for keys. If a modifier is released, that modifier is returned as an actual keycode (e.g. `KEY.LSHIFT`) while the other held modifiers are returned as `KEY.OL_MOD_...` flags.
+    /// Shows a fullscreen key picker with a message, with the accepted input type (keyboard/mouse) filtered by flags. The picker won't show before all previously held keys have been released and other key pickers have returned a valid key.
+    int64_t key_picker(std::string message, KEY_TYPE flags);
 
   private:
     class LuaBackend* backend;

--- a/src/game_api/state.cpp
+++ b/src/game_api/state.cpp
@@ -42,6 +42,11 @@ static int64_t global_frame_count{0};
 static int64_t global_update_count{0};
 static bool g_forward_blocked_events{false};
 
+bool get_forward_events()
+{
+    return g_forward_blocked_events;
+}
+
 uint16_t StateMemory::get_correct_ushabti() // returns animation_frame of ushabti
 {
     return (correct_ushabti + (correct_ushabti / 10) * 2);

--- a/src/game_api/state.cpp
+++ b/src/game_api/state.cpp
@@ -309,6 +309,7 @@ State& State::get()
             init_game_loop_hook();
 
             auto bucket = Bucket::get();
+            bucket->count++;
             if (!bucket->patches_applied)
             {
                 DEBUG("Applying patches");

--- a/src/game_api/state.hpp
+++ b/src/game_api/state.hpp
@@ -408,3 +408,5 @@ uint32_t lowbias32_r(uint32_t x);
 int64_t get_global_frame_count();
 int64_t get_global_update_count();
 void update_camera_position();
+
+bool get_forward_events();

--- a/src/game_api/window_api.cpp
+++ b/src/game_api/window_api.cpp
@@ -13,6 +13,7 @@
 #include "bucket.hpp"
 #include "logger.h"
 #include "memory.hpp"
+#include "script/lua_backend.hpp"
 #include "state.hpp"
 
 bool detect_wine()
@@ -112,6 +113,11 @@ bool HID_UnregisterDevice(USHORT usage)
 LRESULT CALLBACK hkWndProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
 {
     static const auto bucket = Bucket::get();
+
+    if (message == WM_HOTKEY)
+        LuaBackend::wm_hotkey((int)wParam);
+    else if (message == WM_ACTIVATE)
+        LuaBackend::wm_activate((bool)wParam);
 
     bucket->pause_api->modifiers_down = 0;
     if (ImGui::GetIO().KeyCtrl)

--- a/src/game_api/window_api.cpp
+++ b/src/game_api/window_api.cpp
@@ -132,7 +132,7 @@ LRESULT CALLBACK hkWndProc(HWND window, UINT message, WPARAM wParam, LPARAM lPar
     /*if (bucket->io->WantCaptureKeyboard.value_or(false) && (message == WM_KEYDOWN || message == WM_KEYUP))
         consumed_input = true;*/
 
-    if (bucket->io->WantCaptureMouse.value_or(false) && message >= WM_LBUTTONDOWN && message <= WM_MOUSEWHEEL)
+    if (get_forward_events() && bucket->io->WantCaptureMouse.value_or(false) && message >= WM_LBUTTONDOWN && message <= WM_MOUSEWHEEL)
         consumed_input = true;
 
     if (!consumed_input)

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -2844,7 +2844,7 @@ bool process_keys(UINT nCode, WPARAM wParam, [[maybe_unused]] LPARAM lParam)
     auto& io = ImGui::GetIO();
     ImGuiWindow* current = g.NavWindow;
 
-    if (nCode == WM_KEYUP && !io.WantCaptureKeyboard)
+    if (nCode == WM_KEYUP && !io.WantCaptureKeyboard && !g_bucket->io->WantCaptureKeyboard.value_or(false))
     {
         if (pressed("speedhack_turbo", wParam))
         {
@@ -2893,6 +2893,9 @@ bool process_keys(UINT nCode, WPARAM wParam, [[maybe_unused]] LPARAM lParam)
         }
         return true;
     }
+
+    if (g_bucket->io->WantCaptureKeyboard.value_or(false))
+        return false;
 
     if (pressed("hide_ui", wParam))
     {
@@ -5060,7 +5063,7 @@ void render_clickhandler()
             ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDocking);
     if (ImGui::IsWindowHovered())
         io.WantCaptureMouse = options["mouse_control"];
-    if (io.MouseWheel != 0 && ImGui::IsWindowHovered())
+    if (io.MouseWheel != 0 && ImGui::IsWindowHovered() && !g_bucket->io->WantCaptureMouse.value_or(false))
     {
         if (clicked("mouse_zoom_out") || (held("mouse_camera_drag") && io.MouseWheel < 0))
         {
@@ -5272,7 +5275,7 @@ void render_clickhandler()
     }
     using namespace std::chrono_literals;
     auto now = std::chrono::system_clock::now();
-    if (options["mouse_control"] && now > last_focus_time + 200ms && (!options["menu_ui"] || mouse_pos().y > ImGui::GetTextLineHeight()))
+    if (options["mouse_control"] && now > last_focus_time + 200ms && (!options["menu_ui"] || mouse_pos().y > ImGui::GetTextLineHeight()) && !g_bucket->io->WantCaptureMouse.value_or(false))
     {
         ImGui::InvisibleButton("canvas", ImGui::GetContentRegionMax(), ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight);
         if (ImGui::BeginDragDropTarget())

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -782,6 +782,10 @@ std::string key_string(int64_t keycode)
         name = buttonss.str();
     }
 
+    if (keycode & OL_KEY_ALT)
+    {
+        name = "Alt+" + name;
+    }
     if (keycode & OL_KEY_SHIFT)
     {
         name = "Shift+" + name;
@@ -789,10 +793,6 @@ std::string key_string(int64_t keycode)
     if (keycode & OL_KEY_CTRL)
     {
         name = "Ctrl+" + name;
-    }
-    if (keycode & OL_KEY_ALT)
-    {
-        name = "Alt+" + name;
     }
     return name;
 }

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -765,7 +765,7 @@ std::string key_string(int64_t keycode)
         }
         if (result == 0)
         {
-            name = "Mystery key";
+            name = "Unknown";
         }
         std::string keyname(szName);
         name = keyname;
@@ -782,13 +782,13 @@ std::string key_string(int64_t keycode)
         name = buttonss.str();
     }
 
-    if (keycode & OL_KEY_ALT)
-    {
-        name = "Alt+" + name;
-    }
     if (keycode & OL_KEY_SHIFT)
     {
         name = "Shift+" + name;
+    }
+    if (keycode & OL_KEY_ALT)
+    {
+        name = "Alt+" + name;
     }
     if (keycode & OL_KEY_CTRL)
     {
@@ -5891,10 +5891,12 @@ void render_keyconfig()
             if (io.MouseDown[i])
             {
                 size_t keycode = 0x400 + i + 1;
-                if (io.KeysDown[VK_CONTROL])
+                if (ImGui::GetIO().KeyCtrl)
                     keycode += 0x100;
-                if (io.KeysDown[VK_SHIFT])
+                if (ImGui::GetIO().KeyShift)
                     keycode += 0x200;
+                if (ImGui::GetIO().KeyAlt)
+                    keycode += 0x800;
                 keys[g_change_key] = keycode;
                 save_config(cfgfile);
                 g_change_key = "";
@@ -5909,19 +5911,21 @@ void render_keyconfig()
                 keycode += OL_WHEEL_DOWN;
             else if (io.MouseWheel > 0)
                 keycode += OL_WHEEL_UP;
-            if (io.KeysDown[VK_CONTROL])
+            if (ImGui::GetIO().KeyCtrl)
                 keycode += 0x100;
-            if (io.KeysDown[VK_SHIFT])
+            if (ImGui::GetIO().KeyShift)
                 keycode += 0x200;
+            if (ImGui::GetIO().KeyAlt)
+                keycode += 0x800;
             keys[g_change_key] = keycode;
             save_config(cfgfile);
             g_change_key = "";
         }
 
         // Keys
-        for (size_t i = 0; i < VK_LSHIFT; ++i)
+        for (size_t i = 0; i < 0xFF; ++i)
         {
-            if (ImGui::IsKeyDown((ImGuiKey)i))
+            if (ImGui::IsKeyReleased((ImGuiKey)i))
             {
                 size_t keycode = i;
                 if (ImGui::GetIO().KeyCtrl)


### PR DESCRIPTION
- Fixed most of the issues with OL and PL inputs clashing and doing stuff in both. OL now ignores keyboard / mouse input when PL is typing / hovering UI
- Also fixed `ImGuiIO.wantkeyboard` to disable input in the other tool
- Added `set_hotkey(fun(chord), KEY chord, HOTKEY_TYPE flags)` to hook keys though global windows hotkeys, which should once and for all skip all game input and other UI input
- Added `GuiDrawContext:key_picker(string message, KEY_TYPE flags)` to capture any key easily
- Added some more input functions and documentation to `ImGuiIO`