### PR TITLE
Godmode fix

### DIFF
--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -1943,10 +1943,12 @@ void force_cheats()
             ent->poison_tick_timer = -1;
             ent->onfire_effect_timer = 0;
             ent->wet_effect_timer = 0;
-            ent->lock_input_timer = 0;
             ent->set_cursed(false, false);
             ent->more_flags &= ~(1U << 16);
             UI::destroy_entity_item_type(ent, ink);
+            static auto spikes_item = to_id("ENT_TYPE_ITEM_SPIKES");
+            if (ent->overlay && ent->overlay->type->id == spikes_item)
+                ent->detach(false);
         }
     }
     if (options["fly_mode"])
@@ -3089,6 +3091,11 @@ bool process_keys(UINT nCode, WPARAM wParam, [[maybe_unused]] LPARAM lParam)
     {
         options["god_mode"] = !options["god_mode"];
         UI::godmode(options["god_mode"]);
+        if (options["god_mode"])
+        {
+            for (auto ent : g_players)
+                ent->lock_input_timer = 0;
+        }
     }
     else if (pressed("toggle_noclip", wParam))
     {


### PR DESCRIPTION
- don't force `lock_input_timer` to 0 every frame
- fix the floating in the air when fallen into item spikes (movable spikes on hundun platform)


Fixes #381
`lock_input_timer` is also used by the tentacles at the bottom of tiamat and abzu to lock you out of controls before dropping into the abyss. Thou i don't think it's that big of a deal