### PR TITLE
Fix the slight inconsistency of the `Deprecated functions` in the doc

### DIFF
--- a/docs/generate.py
+++ b/docs/generate.py
@@ -97,9 +97,12 @@ def format_af(lf, af):
     return fun
 
 
-def print_af(lf, af):
+def print_af(lf, af, deprecated = False):
     fun = format_af(lf, af)
-    print(f"#### {fun}\n")
+    if deprecated:
+        print(f"`{fun}`<br/>")
+    else:
+        print(f"#### {fun}\n")
     comments = af["comment"]
     if comments:
         comment = " ".join(comments)
@@ -108,7 +111,7 @@ def print_af(lf, af):
         print()
 
 
-def print_lf(lf):
+def print_lf(lf, deprecated = False):
     comments = lf["comment"]
     if comments and "NoDoc" in comments[0]:
         return
@@ -120,7 +123,7 @@ def print_lf(lf):
     include_example(name)
     print(f"\n> Search script examples for [{name}]({search_link})\n")
     for af in ps.rpcfunc(lf["cpp"]):
-        print_af(lf, af)
+        print_af(lf, af, deprecated)
     for com in comments:
         com = link_custom_type(com)
         print(com)
@@ -552,7 +555,7 @@ for lf in ps.events:
 for lf in ps.deprecated_funcs:
     lf["comment"].pop(0)
     if len(ps.rpcfunc(lf["cpp"])):
-        print_lf(lf)
+        print_lf(lf, True)
     elif not (lf["name"].startswith("on_") or lf["name"] in ps.not_functions):
         if lf["comment"] and "NoDoc" in lf["comment"][0]:
             continue

--- a/docs/src/includes/_globals.md
+++ b/docs/src/includes/_globals.md
@@ -3874,8 +3874,7 @@ Set level flag 18 on post room generation instead, to properly force every level
 
 > Search script examples for [get_entities](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=get_entities)
 
-#### vector&lt;int&gt; get_entities()
-
+`vector&lt;int&gt; get_entities()`<br/>
 Use `get_entities_by(0, MASK.ANY, LAYER.BOTH)` instead
 
 ### get_entities_by_mask
@@ -3883,8 +3882,7 @@ Use `get_entities_by(0, MASK.ANY, LAYER.BOTH)` instead
 
 > Search script examples for [get_entities_by_mask](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=get_entities_by_mask)
 
-#### vector&lt;int&gt; get_entities_by_mask(int mask)
-
+`vector&lt;int&gt; get_entities_by_mask(int mask)`<br/>
 Use `get_entities_by(0, mask, LAYER.BOTH)` instead
 
 ### get_entities_by_layer
@@ -3892,8 +3890,7 @@ Use `get_entities_by(0, mask, LAYER.BOTH)` instead
 
 > Search script examples for [get_entities_by_layer](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=get_entities_by_layer)
 
-#### vector&lt;int&gt; get_entities_by_layer([LAYER](#LAYER) layer)
-
+`vector&lt;int&gt; get_entities_by_layer([LAYER](#LAYER) layer)`<br/>
 Use `get_entities_by(0, MASK.ANY, layer)` instead
 
 ### get_entities_overlapping
@@ -3901,10 +3898,8 @@ Use `get_entities_by(0, MASK.ANY, layer)` instead
 
 > Search script examples for [get_entities_overlapping](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=get_entities_overlapping)
 
-#### vector&lt;int&gt; get_entities_overlapping(array<[ENT_TYPE](#ENT_TYPE)> entity_types, int mask, float sx, float sy, float sx2, float sy2, [LAYER](#LAYER) layer)
-
-#### vector&lt;int&gt; get_entities_overlapping([ENT_TYPE](#ENT_TYPE) entity_type, int mask, float sx, float sy, float sx2, float sy2, [LAYER](#LAYER) layer)
-
+`vector&lt;int&gt; get_entities_overlapping(array<[ENT_TYPE](#ENT_TYPE)> entity_types, int mask, float sx, float sy, float sx2, float sy2, [LAYER](#LAYER) layer)`<br/>
+`vector&lt;int&gt; get_entities_overlapping([ENT_TYPE](#ENT_TYPE) entity_type, int mask, float sx, float sy, float sx2, float sy2, [LAYER](#LAYER) layer)`<br/>
 Use `get_entities_overlapping_hitbox` instead
 
 ### get_entity_ai_state
@@ -3912,8 +3907,7 @@ Use `get_entities_overlapping_hitbox` instead
 
 > Search script examples for [get_entity_ai_state](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=get_entity_ai_state)
 
-#### int get_entity_ai_state(int uid)
-
+`int get_entity_ai_state(int uid)`<br/>
 As the name is misleading. use [Movable](#Movable).`move_state` field instead
 
 ### set_arrowtrap_projectile
@@ -3921,8 +3915,7 @@ As the name is misleading. use [Movable](#Movable).`move_state` field instead
 
 > Search script examples for [set_arrowtrap_projectile](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=set_arrowtrap_projectile)
 
-#### nil set_arrowtrap_projectile([ENT_TYPE](#ENT_TYPE) regular_entity_type, [ENT_TYPE](#ENT_TYPE) poison_entity_type)
-
+`nil set_arrowtrap_projectile([ENT_TYPE](#ENT_TYPE) regular_entity_type, [ENT_TYPE](#ENT_TYPE) poison_entity_type)`<br/>
 Use [replace_drop](#replace_drop)([DROP](#DROP).ARROWTRAP_WOODENARROW, new_arrow_type) and [replace_drop](#replace_drop)([DROP](#DROP).POISONEDARROWTRAP_WOODENARROW, new_arrow_type) instead
 
 ### set_blood_multiplication
@@ -3930,8 +3923,7 @@ Use [replace_drop](#replace_drop)([DROP](#DROP).ARROWTRAP_WOODENARROW, new_arrow
 
 > Search script examples for [set_blood_multiplication](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=set_blood_multiplication)
 
-#### nil set_blood_multiplication(int default_multiplier, int vladscape_multiplier)
-
+`nil set_blood_multiplication(int default_multiplier, int vladscape_multiplier)`<br/>
 This function never worked properly as too many places in the game individually check for vlads cape and calculate the blood multiplication
 `default_multiplier` doesn't do anything due to some changes in last game updates, `vladscape_multiplier` only changes the multiplier to some entities death's blood spit
 
@@ -4200,8 +4192,7 @@ Use this only when no other approach works, this call can be expensive if overus
 
 > Search script examples for [generate_particles](https://github.com/spelunky-fyi/overlunky/search?l=Lua&q=generate_particles)
 
-#### [ParticleEmitterInfo](#ParticleEmitterInfo) generate_particles([PARTICLEEMITTER](#PARTICLEEMITTER) particle_emitter_id, int uid)
-
+`[ParticleEmitterInfo](#ParticleEmitterInfo) generate_particles([PARTICLEEMITTER](#PARTICLEEMITTER) particle_emitter_id, int uid)`<br/>
 Use `generate_world_particles`
 
 ### draw_line


### PR DESCRIPTION
Mentioned on discord

I guessed there was some intend to format the deprecated functions differently, so I made it consistent