### PR TITLE
Fix option `Light dark levels and layers` not returning the level illumination to normal after switching it in the UI

### DIFF
--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -1789,22 +1789,13 @@ void force_lights()
     if (options["lights"])
     {
         if (!g_state->illumination && g_state->screen == 12)
-        {
             g_state->illumination = UI::create_illumination(Color::white(), 20000.0f, 172, 252);
-        }
+
         if (g_state->illumination)
         {
             g_state->illumination->enabled = true;
-            if (g_state->camera_layer == 1)
-                g_state->illumination->flags |= 1U << 16;
-            else
-                g_state->illumination->flags &= ~(1U << 16);
+            g_state->illumination->layer = g_state->camera_layer;
         }
-    }
-    else
-    {
-        if (g_state->illumination && test_flag(g_state->level_flags, 18))
-            g_state->illumination->enabled = false;
     }
 }
 
@@ -2797,13 +2788,13 @@ void toggle_lights()
 {
     if (options["lights"] && g_state->illumination)
     {
-        g_state->illumination->flags |= (1U << 24);
+        g_state->illumination->enabled = true;
     }
     else if (!options["lights"] && g_state->illumination)
     {
-        g_state->illumination->flags &= ~(1U << 16);
-        if ((g_state->level_flags & (1U << 17)) > 0)
-            g_state->illumination->flags &= ~(1U << 24);
+        g_state->illumination->layer = 0;
+        if (test_flag(g_state->level_flags, 18)) // dark level
+            g_state->illumination->enabled = false;
     }
 }
 
@@ -5989,7 +5980,9 @@ void render_options()
         tooltip("Fly through walls and ignored by enemies.", "toggle_noclip");
         ImGui::Checkbox("Fly mode##FlyMode", &options["fly_mode"]);
         tooltip("Fly while holding the jump button.", "toggle_flymode");
-        ImGui::Checkbox("Light dark levels and layers##DrawLights", &options["lights"]);
+        if (ImGui::Checkbox("Light dark levels and layers##DrawLights", &options["lights"]))
+            toggle_lights();
+
         tooltip("Enables the default level lighting everywhere.", "toggle_lights");
         if (ImGui::CheckboxFlags("Force dark levels", &g_dark_mode, 1))
         {


### PR DESCRIPTION
Currently when you go to back layer and switch "Light dark levels and layers" on and the off thru the UI, the illumination stays in the back layer