### PR TITLE
Fix current callback being overwritten if another one starts before the first one finished execution

### DIFF
--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -1660,21 +1660,20 @@ bool LuaBackend::pre_set_feat(FEAT feat)
 
 CurrentCallback LuaBackend::get_current_callback() const
 {
-    return current_cb;
+    if (current_cb.empty())
+        return {0, 0, CallbackType::None};
+
+    return current_cb.front();
 }
 
 void LuaBackend::set_current_callback(int32_t aux_id, int32_t id, CallbackType type)
 {
-    current_cb.aux_id = aux_id;
-    current_cb.id = id;
-    current_cb.type = type;
+    current_cb.emplace_front(aux_id, id, type);
 }
 
 void LuaBackend::clear_current_callback()
 {
-    current_cb.aux_id = 0;
-    current_cb.id = 0;
-    current_cb.type = CallbackType::None;
+    current_cb.pop_front();
 }
 
 void LuaBackend::set_error(std::string err)

--- a/src/game_api/script/lua_backend.hpp
+++ b/src/game_api/script/lua_backend.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>       // for uint32_t, uint16_t, uint8_t, int32_t
 #include <deque>         // for deque
 #include <filesystem>    // for path
+#include <forward_list>  // for forward_list
 #include <functional>    // for equal_to, function, less
 #include <imgui.h>       // for ImDrawList (ptr only), ImVec4
 #include <locale>        // for num_get, num_put
@@ -311,7 +312,7 @@ class LuaBackend
     std::string result;
 
     int cbcount = 0;
-    CurrentCallback current_cb = {0, 0, CallbackType::None};
+    std::forward_list<CurrentCallback> current_cb;
 
     std::map<std::string, ScriptOption> options;
     std::deque<ScriptMessage> messages;


### PR DESCRIPTION
Daft because i didn't test if there are possible situations when the calls to `set_current_callback` and `clear_current_callback` are uneven