### PR TITLE
Fix SoundManager lifetime and other sound bugs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: Build
 
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Continuous Integration ${{ matrix.target_name }} ${{ matrix.toolset_name }} ${{ matrix.build_type }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         build_type: [Debug, Release]

--- a/.github/workflows/docs_verify.yml
+++ b/.github/workflows/docs_verify.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/whip-build.yml
+++ b/.github/workflows/whip-build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: Build
 
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: llvm/actions/install-ninja@main
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,7 +140,12 @@ if(BUILD_OVERLUNKY)
         # --------------------------------------------------
         # toml11
         option(toml11_BUILD_TEST OFF)
+
+        # toml11 commit we're at sets cmake_minimum_required(VERSION 3.1) which fails in CI where 4.0 is used.
+        # Scoped to this add_subdirectory so it doesn't affect the rest of the project.
+        set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
         add_subdirectory(toml11)
+        unset(CMAKE_POLICY_VERSION_MINIMUM)
 
         if(MSVC)
                 # --------------------------------------------------

--- a/src/game_api/script/usertypes/sound_lua.cpp
+++ b/src/game_api/script/usertypes/sound_lua.cpp
@@ -38,18 +38,12 @@ namespace NSound
 {
 void register_usertypes(sol::state& lua, SoundManager* sound_manager)
 {
-    assert(sound_manager != nullptr && sound_manager->is_init());
+    assert(sound_manager != nullptr);
     if (sound_manager == nullptr)
     {
         DEBUG("Audio API is not available!");
         return;
     }
-    if (!sound_manager->is_init())
-    {
-        DEBUG("Audio API is not initialized!");
-        return;
-    }
-
     /// Parameter to `load_bank()`, used to control bank loading.
     lua.new_enum("FMOD_LOAD_BANK_FLAGS", "NORMAL", FMODStudio::LoadBankFlags::Normal, "NONBLOCKING", FMODStudio::LoadBankFlags::Nonblocking, "DECOMPRESS_SAMPLES", FMODStudio::LoadBankFlags::DecompressSamples, "UNENCRYPTED", FMODStudio::LoadBankFlags::Unencrypted);
     /* FMOD_LOAD_BANK_FLAGS
@@ -345,7 +339,10 @@ void register_usertypes(sol::state& lua, SoundManager* sound_manager)
 
         auto backend = LuaBackend::get_calling_backend();
         std::uint32_t id = backend->sound_manager->set_callback(name, std::move(safe_cb), static_cast<FMODStudio::EventCallbackType>(types));
-        backend->vanilla_sound_callbacks.push_back(id);
+        if (id != INVALID_SOUND_CALLBACK_ID)
+        {
+            backend->vanilla_sound_callbacks.push_back(id);
+        }
         return id;
     };
     /// Clears a previously set callback
@@ -452,7 +449,13 @@ void register_usertypes(sol::state& lua, SoundManager* sound_manager)
         sol::property([](SoundInfo& si)                 // -> VANILLA_SOUND
                       { return si.sound_name /**/; })); // return copy, so it's read only
 
-    auto play_sound = sol::overload(static_cast<SoundMeta* (*)(SOUNDID, uint32_t)>(::play_sound), static_cast<SoundMeta* (*)(VANILLA_SOUND, uint32_t)>(::play_sound));
+    auto play_sound = sol::overload(
+        static_cast<SoundMeta* (*)(SOUNDID, uint32_t)>(::play_sound),
+        [](VANILLA_SOUND sound, uint32_t source_uid) -> SoundMeta*
+        {
+            auto backend = LuaBackend::get_calling_backend();
+            return ::play_sound(backend->sound_manager->convert_sound_id(sound), source_uid);
+        });
 
     /// Use source_uid to make the sound be played at the location of that entity, set it -1 to just play it "everywhere"
     /// Returns SoundMeta, beware that the sound can't be stopped (`start_over` and `playing` are unavailable). Should only be used for sfx.

--- a/src/game_api/sound_manager.cpp
+++ b/src/game_api/sound_manager.cpp
@@ -34,6 +34,8 @@ struct SoundCallbackData
 {
     FMOD::Channel* handle;
     SoundCallbackFunction callback;
+
+    inline static FMOD::ChannelSetCallback* ChannelSetCallback{nullptr};
 };
 std::mutex s_SoundCallbacksMutex;
 std::vector<SoundCallbackData> s_SoundCallbacks;
@@ -84,12 +86,65 @@ struct EventCallbackData
     FMODStudio::EventDescription* handle;
     std::unordered_map<FMODStudio::EventCallbackType, std::vector<Callback>> callbacks;
     std::unordered_map<FMODStudio::EventInstance*, SoundCallbackFunction> specific_callbacks;
-    SoundManager* sound_manager;
+    // Identity only, never dereferenced. ~SoundManager needs to find its own entries, and by then
+    // the weak_ptr below has already expired (the strong count hits 0 before the body runs).
+    SoundManager* owner;
+    std::weak_ptr<SoundManager> sound_manager;
 
     inline static FMODStudio::EventInstanceGetDescription* EventInstanceGetDescription{nullptr};
+    inline static FMODStudio::EventDescriptionSetCallback* EventDescriptionSetCallback{nullptr};
+    inline static FMODStudio::EventInstanceSetCallback* EventInstanceSetCallback{nullptr};
+
+    // Whether we installed EventInstanceCallback on `handle` itself. Entries created by
+    // set_callback(PlayingSound, ...) only hook individual instances, so detaching the
+    // description would clobber a callback the game (or another mod) owns.
+    bool description_callback_installed{false};
 };
+
+// Handles to unhook from FMOD.
+struct PendingDetach
+{
+    std::vector<FMODStudio::EventDescription*> events;
+    std::vector<FMODStudio::EventInstance*> instances;
+};
+
+// Vanilla event descriptions are owned by the game and outlive the SoundManager.
+// A callback left installed here means FMOD eventually calls into freed code.
+void collect_event_detach(EventCallbackData& data, PendingDetach& pending)
+{
+    if (data.handle != nullptr && data.description_callback_installed)
+    {
+        pending.events.push_back(data.handle);
+        data.description_callback_installed = false;
+    }
+    for (auto& [instance, _] : data.specific_callbacks)
+    {
+        pending.instances.push_back(instance);
+    }
+    data.callbacks.clear();
+    data.specific_callbacks.clear();
+}
+
+void apply_event_detach(const PendingDetach& pending)
+{
+    if (EventCallbackData::EventDescriptionSetCallback != nullptr)
+    {
+        for (FMODStudio::EventDescription* event : pending.events)
+        {
+            EventCallbackData::EventDescriptionSetCallback(event, nullptr, FMODStudio::EventCallbackType::All);
+        }
+    }
+    if (EventCallbackData::EventInstanceSetCallback != nullptr)
+    {
+        for (FMODStudio::EventInstance* instance : pending.instances)
+        {
+            EventCallbackData::EventInstanceSetCallback(instance, nullptr, FMODStudio::EventCallbackType::All);
+        }
+    }
+}
 std::mutex s_EventCallbacksMutex;
-std::uint32_t current_callback_id{0};
+// 0 is reserved for INVALID_SOUND_CALLBACK_ID
+std::uint32_t current_callback_id{1};
 std::vector<EventCallbackData> s_EventCallbacks;
 std::unordered_map<std::uint32_t, FMODStudio::EventDescription*> s_EventCallbackIdToEventDescription;
 FMOD::FMOD_RESULT EventInstanceCallback(FMODStudio::EventCallbackType callback_type, FMODStudio::EventInstance* instance, void*)
@@ -97,7 +152,7 @@ FMOD::FMOD_RESULT EventInstanceCallback(FMODStudio::EventCallbackType callback_t
     FMODStudio::EventDescription* event;
     if (FMOD_CHECK_CALL(EventCallbackData::EventInstanceGetDescription(instance, &event)))
     {
-        SoundManager* sound_manager{nullptr};
+        std::weak_ptr<SoundManager> sound_manager;
         std::vector<EventCallbackFunction> evt_callbacks;
         SoundCallbackFunction snd_callback;
 
@@ -146,15 +201,29 @@ FMOD::FMOD_RESULT EventInstanceCallback(FMODStudio::EventCallbackType callback_t
     return FMOD::FMOD_RESULT::OK;
 }
 
+// Locks the owning manager for the duration of one handle call. If the manager is already gone the
+// handle is degraded to monostate, so the caller's existing monostate branch yields that function's
+// established failure value.
+template <class HandleT>
+std::shared_ptr<SoundManager> lock_manager(std::weak_ptr<SoundManager>& weak_manager, HandleT& handle)
+{
+    auto sound_manager = weak_manager.lock();
+    if (!sound_manager)
+    {
+        handle = std::monostate{};
+    }
+    return sound_manager;
+}
+
 CustomSound::CustomSound(const CustomSound& rhs)
     : m_FmodHandle{rhs.m_FmodHandle}, m_SoundManager{rhs.m_SoundManager}
 {
-    if (m_SoundManager != nullptr)
+    if (auto sound_manager = m_SoundManager.lock())
     {
         std::visit(
             overloaded{
-                [this](FMOD::Sound* sound)
-                { m_SoundManager->acquire_sound(sound); },
+                [&](FMOD::Sound* sound)
+                { sound_manager->acquire_sound(sound); },
                 [](FMODStudio::EventDescription*) {},
                 [](std::monostate) {},
             },
@@ -166,23 +235,23 @@ CustomSound::CustomSound(CustomSound&& rhs) noexcept
     std::swap(m_FmodHandle, rhs.m_FmodHandle);
     std::swap(m_SoundManager, rhs.m_SoundManager);
 }
-CustomSound::CustomSound(FMOD::Sound* fmod_sound, SoundManager* sound_manager)
+CustomSound::CustomSound(FMOD::Sound* fmod_sound, std::weak_ptr<SoundManager> sound_manager)
     : m_FmodHandle{fmod_sound}, m_SoundManager{sound_manager}
 {
 }
-CustomSound::CustomSound(FMODStudio::EventDescription* fmod_event, SoundManager* sound_manager)
+CustomSound::CustomSound(FMODStudio::EventDescription* fmod_event, std::weak_ptr<SoundManager> sound_manager)
     : m_FmodHandle{fmod_event}, m_SoundManager{sound_manager}
 {
 }
 
 CustomSound::~CustomSound()
 {
-    if (m_SoundManager != nullptr)
+    if (auto sound_manager = m_SoundManager.lock())
     {
         std::visit(
             overloaded{
-                [this](FMOD::Sound* sound)
-                { m_SoundManager->acquire_sound(sound); },
+                [&](FMOD::Sound* sound)
+                { sound_manager->acquire_sound(sound); },
                 [](FMODStudio::EventDescription*) {},
                 [](std::monostate) {},
             },
@@ -200,12 +269,13 @@ PlayingSound CustomSound::play(bool paused)
 }
 PlayingSound CustomSound::play(bool paused, SOUND_TYPE sound_type)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [=, this](FMOD::Sound* sound)
-            { return m_SoundManager->play_sound(sound, paused, sound_type == SOUND_TYPE::Music); },
-            [=, this](FMODStudio::EventDescription* event)
-            { return m_SoundManager->play_event(event, paused, sound_type == SOUND_TYPE::Music); },
+            [&](FMOD::Sound* sound)
+            { return sound_manager->play_sound(sound, paused, sound_type == SOUND_TYPE::Music); },
+            [&](FMODStudio::EventDescription* event)
+            { return sound_manager->play_event(event, paused, sound_type == SOUND_TYPE::Music); },
             [](std::monostate)
             {
                 return PlayingSound{nullptr, nullptr};
@@ -216,86 +286,107 @@ PlayingSound CustomSound::play(bool paused, SOUND_TYPE sound_type)
 
 std::unordered_map<VANILLA_SOUND_PARAM, const char*> CustomSound::get_parameters()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
             [](FMOD::Sound*)
             { return std::unordered_map<VANILLA_SOUND_PARAM, const char*>{}; },
-            [this](FMODStudio::EventDescription* event)
-            { return m_SoundManager->get_parameters(event); },
+            [&](FMODStudio::EventDescription* event)
+            { return sound_manager->get_parameters(event); },
             [](std::monostate)
             { return std::unordered_map<VANILLA_SOUND_PARAM, const char*>{}; },
         },
         m_FmodHandle);
 }
 
-PlayingSound::PlayingSound(FMOD::Channel* fmod_channel, SoundManager* sound_manager)
+PlayingSound::PlayingSound(FMOD::Channel* fmod_channel, std::weak_ptr<SoundManager> sound_manager)
     : m_FmodHandle{fmod_channel}, m_SoundManager{sound_manager}
 {
 }
-PlayingSound::PlayingSound(FMODStudio::EventInstance* fmod_event, SoundManager* sound_manager)
+PlayingSound::PlayingSound(FMODStudio::EventInstance* fmod_event, std::weak_ptr<SoundManager> sound_manager)
     : m_FmodHandle{fmod_event}, m_SoundManager{sound_manager}
 {
 }
 
 bool PlayingSound::is_playing()
 {
-    return m_SoundManager->is_playing(*this);
+    auto sound_manager = m_SoundManager.lock();
+    return sound_manager && sound_manager->is_playing(*this);
 }
 bool PlayingSound::stop()
 {
-    return m_SoundManager->stop(*this);
+    auto sound_manager = m_SoundManager.lock();
+    return sound_manager && sound_manager->stop(*this);
 }
 bool PlayingSound::set_pause(bool pause)
 {
-    return m_SoundManager->set_pause(*this, pause);
+    auto sound_manager = m_SoundManager.lock();
+    return sound_manager && sound_manager->set_pause(*this, pause);
 }
 bool PlayingSound::set_mute(bool mute)
 {
-    return m_SoundManager->set_mute(*this, mute);
+    auto sound_manager = m_SoundManager.lock();
+    return sound_manager && sound_manager->set_mute(*this, mute);
 }
 bool PlayingSound::set_pitch(float pitch)
 {
-    return m_SoundManager->set_pitch(*this, pitch);
+    auto sound_manager = m_SoundManager.lock();
+    return sound_manager && sound_manager->set_pitch(*this, pitch);
 }
 bool PlayingSound::set_pan(float pan)
 {
-    return m_SoundManager->set_pan(*this, pan);
+    auto sound_manager = m_SoundManager.lock();
+    return sound_manager && sound_manager->set_pan(*this, pan);
 }
 bool PlayingSound::set_volume(float volume)
 {
-    return m_SoundManager->set_volume(*this, volume);
+    auto sound_manager = m_SoundManager.lock();
+    return sound_manager && sound_manager->set_volume(*this, volume);
 }
 bool PlayingSound::set_looping(SOUND_LOOP_MODE loop_mode)
 {
-    return m_SoundManager->set_looping(*this, loop_mode);
+    auto sound_manager = m_SoundManager.lock();
+    return sound_manager && sound_manager->set_looping(*this, loop_mode);
 }
 bool PlayingSound::set_callback(SoundCallbackFunction callback)
 {
-    return m_SoundManager->set_callback(*this, std::move(callback));
+    auto sound_manager = m_SoundManager.lock();
+    return sound_manager && sound_manager->set_callback(*this, std::move(callback));
 }
 
 std::unordered_map<VANILLA_SOUND_PARAM, const char*> PlayingSound::get_parameters()
 {
-    return m_SoundManager->get_parameters(*this);
+    auto sound_manager = m_SoundManager.lock();
+    if (!sound_manager)
+    {
+        return std::unordered_map<VANILLA_SOUND_PARAM, const char*>{};
+    }
+    return sound_manager->get_parameters(*this);
 }
 std::optional<float> PlayingSound::get_parameter(VANILLA_SOUND_PARAM parameter_index)
 {
-    return m_SoundManager->get_parameter(*this, parameter_index);
+    auto sound_manager = m_SoundManager.lock();
+    if (!sound_manager)
+    {
+        return std::nullopt;
+    }
+    return sound_manager->get_parameter(*this, parameter_index);
 }
 bool PlayingSound::set_parameter(VANILLA_SOUND_PARAM parameter_index, float value)
 {
-    return m_SoundManager->set_parameter(*this, parameter_index, value);
+    auto sound_manager = m_SoundManager.lock();
+    return sound_manager && sound_manager->set_parameter(*this, parameter_index, value);
 }
 
 CustomBank::CustomBank(const CustomBank& rhs)
     : m_FmodHandle{rhs.m_FmodHandle}, m_SoundManager{rhs.m_SoundManager}
 {
-    if (m_SoundManager != nullptr)
+    if (auto sound_manager = m_SoundManager.lock())
     {
         std::visit(
             overloaded{
-                [this](FMOD::Bank* bank)
-                { m_SoundManager->acquire_bank(bank); },
+                [&](FMOD::Bank* bank)
+                { sound_manager->acquire_bank(bank); },
                 [](std::monostate) {},
             },
             rhs.m_FmodHandle);
@@ -306,17 +397,18 @@ CustomBank::CustomBank(CustomBank&& rhs) noexcept
     std::swap(m_FmodHandle, rhs.m_FmodHandle);
     std::swap(m_SoundManager, rhs.m_SoundManager);
 }
-CustomBank::CustomBank(FMOD::Bank* fmod_bank, SoundManager* sound_manager)
+CustomBank::CustomBank(FMOD::Bank* fmod_bank, std::weak_ptr<SoundManager> sound_manager)
     : m_FmodHandle{fmod_bank}, m_SoundManager{sound_manager}
 {
 }
 std::optional<FMODStudio::LoadingState> CustomBank::get_loading_state()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMOD::Bank* bank)
+            [&](FMOD::Bank* bank)
             {
-                return m_SoundManager->get_bank_loading_state(bank);
+                return sound_manager->get_bank_loading_state(bank);
             },
             [](std::monostate)
             { return std::optional<FMODStudio::LoadingState>{}; }},
@@ -324,30 +416,33 @@ std::optional<FMODStudio::LoadingState> CustomBank::get_loading_state()
 }
 bool CustomBank::load_sample_data()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
 
     return std::visit(
-        overloaded{[this](FMOD::Bank* bank)
-                   { return m_SoundManager->load_bank_sample_data(bank); },
+        overloaded{[&](FMOD::Bank* bank)
+                   { return sound_manager->load_bank_sample_data(bank); },
                    [](std::monostate)
                    { return false; }},
         m_FmodHandle);
 }
 bool CustomBank::unload_sample_data()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
-        overloaded{[this](FMOD::Bank* bank)
-                   { return m_SoundManager->unload_bank_sample_data(bank); },
+        overloaded{[&](FMOD::Bank* bank)
+                   { return sound_manager->unload_bank_sample_data(bank); },
                    [](std::monostate)
                    { return false; }},
         m_FmodHandle);
 }
 std::optional<FMODStudio::LoadingState> CustomBank::get_sample_loading_state()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMOD::Bank* bank)
+            [&](FMOD::Bank* bank)
             {
-                return m_SoundManager->get_bank_sample_loading_state(bank);
+                return sound_manager->get_bank_sample_loading_state(bank);
             },
             [](std::monostate)
             { return std::optional<FMODStudio::LoadingState>{}; }},
@@ -355,19 +450,21 @@ std::optional<FMODStudio::LoadingState> CustomBank::get_sample_loading_state()
 }
 bool CustomBank::unload()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [=, this](FMOD::Bank* bank)
-            { return m_SoundManager->unload_bank(bank); },
+            [&](FMOD::Bank* bank)
+            { return sound_manager->unload_bank(bank); },
             [](std::monostate)
             { return false; }},
         m_FmodHandle);
 }
 bool CustomBank::is_valid()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
-        overloaded{[this](FMOD::Bank* bank)
-                   { return m_SoundManager->bank_is_valid(bank); },
+        overloaded{[&](FMOD::Bank* bank)
+                   { return sound_manager->bank_is_valid(bank); },
                    [](std::monostate)
                    { return false; }},
         m_FmodHandle);
@@ -382,16 +479,17 @@ CustomEventDescription::CustomEventDescription(CustomEventDescription&& rhs) noe
     std::swap(m_FmodHandle, rhs.m_FmodHandle);
     std::swap(m_SoundManager, rhs.m_SoundManager);
 }
-CustomEventDescription::CustomEventDescription(FMODStudio::EventDescription* fmod_event, SoundManager* sound_manager)
+CustomEventDescription::CustomEventDescription(FMODStudio::EventDescription* fmod_event, std::weak_ptr<SoundManager> sound_manager)
     : m_FmodHandle{fmod_event}, m_SoundManager{sound_manager}
 {
 }
 std::shared_ptr<CustomEventInstance> CustomEventDescription::create_instance()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [=, this](FMODStudio::EventDescription* event)
-            { return m_SoundManager->event_description_create_instance(event); },
+            [&](FMODStudio::EventDescription* event)
+            { return sound_manager->event_description_create_instance(event); },
             [](std::monostate)
             {
                 return std::make_shared<CustomEventInstance>(nullptr, nullptr);
@@ -401,10 +499,11 @@ std::shared_ptr<CustomEventInstance> CustomEventDescription::create_instance()
 }
 bool CustomEventDescription::release_all_instances()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [=, this](FMODStudio::EventDescription* event)
-            { return m_SoundManager->event_description_release_all_instances(event); },
+            [&](FMODStudio::EventDescription* event)
+            { return sound_manager->event_description_release_all_instances(event); },
             [](std::monostate)
             {
                 return false;
@@ -414,29 +513,32 @@ bool CustomEventDescription::release_all_instances()
 }
 bool CustomEventDescription::load_sample_data()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
-        overloaded{[this](FMODStudio::EventDescription* event)
-                   { return m_SoundManager->event_description_load_sample_data(event); },
+        overloaded{[&](FMODStudio::EventDescription* event)
+                   { return sound_manager->event_description_load_sample_data(event); },
                    [](std::monostate)
                    { return false; }},
         m_FmodHandle);
 }
 bool CustomEventDescription::unload_sample_data()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
-        overloaded{[this](FMODStudio::EventDescription* event)
-                   { return m_SoundManager->event_description_unload_sample_data(event); },
+        overloaded{[&](FMODStudio::EventDescription* event)
+                   { return sound_manager->event_description_unload_sample_data(event); },
                    [](std::monostate)
                    { return false; }},
         m_FmodHandle);
 }
 std::optional<FMODStudio::LoadingState> CustomEventDescription::get_sample_loading_state()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventDescription* event)
+            [&](FMODStudio::EventDescription* event)
             {
-                return m_SoundManager->event_description_get_sample_loading_state(event);
+                return sound_manager->event_description_get_sample_loading_state(event);
             },
             [](std::monostate)
             { return std::optional<FMODStudio::LoadingState>{}; }},
@@ -444,11 +546,12 @@ std::optional<FMODStudio::LoadingState> CustomEventDescription::get_sample_loadi
 }
 std::optional<int> CustomEventDescription::get_parameter_description_count()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventDescription* event)
+            [&](FMODStudio::EventDescription* event)
             {
-                return m_SoundManager->event_description_get_parameter_description_count(event);
+                return sound_manager->event_description_get_parameter_description_count(event);
             },
             [](std::monostate)
             { return std::optional<int>{}; }},
@@ -456,11 +559,12 @@ std::optional<int> CustomEventDescription::get_parameter_description_count()
 }
 std::optional<FMODStudio::ParameterDescription> CustomEventDescription::get_parameter_description_by_name(std::string name)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, name](FMODStudio::EventDescription* event)
+            [&](FMODStudio::EventDescription* event)
             {
-                return m_SoundManager->event_description_get_parameter_description_by_name(event, name);
+                return sound_manager->event_description_get_parameter_description_by_name(event, name);
             },
             [](std::monostate)
             { return std::optional<FMODStudio::ParameterDescription>{}; }},
@@ -468,11 +572,12 @@ std::optional<FMODStudio::ParameterDescription> CustomEventDescription::get_para
 }
 std::optional<FMODStudio::ParameterDescription> CustomEventDescription::get_parameter_description_by_index(int index)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, index](FMODStudio::EventDescription* event)
+            [&](FMODStudio::EventDescription* event)
             {
-                return m_SoundManager->event_description_get_parameter_description_by_index(event, index);
+                return sound_manager->event_description_get_parameter_description_by_index(event, index);
             },
             [](std::monostate)
             { return std::optional<FMODStudio::ParameterDescription>{}; }},
@@ -480,11 +585,12 @@ std::optional<FMODStudio::ParameterDescription> CustomEventDescription::get_para
 }
 std::optional<FMODStudio::ParameterId> CustomEventDescription::get_parameter_id_by_name(std::string name)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, name](FMODStudio::EventDescription* event)
+            [&](FMODStudio::EventDescription* event)
             {
-                return m_SoundManager->event_description_get_parameter_id_by_name(event, name);
+                return sound_manager->event_description_get_parameter_id_by_name(event, name);
             },
             [](std::monostate)
             { return std::optional<FMODStudio::ParameterId>{}; }},
@@ -492,17 +598,30 @@ std::optional<FMODStudio::ParameterId> CustomEventDescription::get_parameter_id_
 }
 bool CustomEventDescription::is_valid()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
-        overloaded{[this](FMODStudio::EventDescription* event)
-                   { return m_SoundManager->event_description_is_valid(event); },
+        overloaded{[&](FMODStudio::EventDescription* event)
+                   { return sound_manager->event_description_is_valid(event); },
                    [](std::monostate)
                    { return false; }},
         m_FmodHandle);
 }
 
-CustomEventInstance::CustomEventInstance(FMODStudio::EventInstance* fmod_event, SoundManager* sound_manager)
+CustomEventInstance::CustomEventInstance(FMODStudio::EventInstance* fmod_event, std::weak_ptr<SoundManager> sound_manager)
     : m_FmodHandle{fmod_event}, m_SoundManager{sound_manager}
 {
+}
+CustomEventInstance::CustomEventInstance(CustomEventInstance&& rhs) noexcept
+{
+    std::swap(m_FmodHandle, rhs.m_FmodHandle);
+    std::swap(m_SoundManager, rhs.m_SoundManager);
+}
+CustomEventInstance& CustomEventInstance::operator=(CustomEventInstance&& rhs) noexcept
+{
+    // Swap rather than overwrite, so rhs's destructor releases whatever we were holding.
+    std::swap(m_FmodHandle, rhs.m_FmodHandle);
+    std::swap(m_SoundManager, rhs.m_SoundManager);
+    return *this;
 }
 CustomEventInstance::~CustomEventInstance()
 {
@@ -510,20 +629,20 @@ CustomEventInstance::~CustomEventInstance()
         overloaded{
             [this](FMODStudio::EventInstance* event_instance)
             {
-                if (m_SoundManager != nullptr)
+                if (auto sound_manager = m_SoundManager.lock())
                 {
-                    if (m_SoundManager->event_instance_is_valid(event_instance))
+                    if (sound_manager->event_instance_is_valid(event_instance))
                     {
-                        if (m_SoundManager->release(event_instance))
+                        if (sound_manager->release(event_instance))
                         {
-                            if (m_SoundManager->event_instance_is_valid(event_instance))
+                            if (sound_manager->event_instance_is_valid(event_instance))
                             {
                                 std::optional<FMODStudio::PlaybackState> playback_state;
-                                playback_state = m_SoundManager->get_playback_state(event_instance);
+                                playback_state = sound_manager->get_playback_state(event_instance);
 
                                 if (!(playback_state == FMODStudio::PlaybackState::Stopping || playback_state == FMODStudio::PlaybackState::Stopped))
                                 {
-                                    if (!m_SoundManager->stop(event_instance, FMODStudio::StopMode::AllowFadeOut))
+                                    if (!sound_manager->stop(event_instance, FMODStudio::StopMode::AllowFadeOut))
                                     {
                                         DEBUG("Failed to automatically stop FMOD event instance...");
                                     }
@@ -543,11 +662,12 @@ CustomEventInstance::~CustomEventInstance()
 }
 bool CustomEventInstance::start()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->start(event_instance);
+                return sound_manager->start(event_instance);
             },
             [](std::monostate)
             { return false; }},
@@ -555,11 +675,12 @@ bool CustomEventInstance::start()
 }
 bool CustomEventInstance::stop()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->stop(event_instance, FMODStudio::StopMode::AllowFadeOut);
+                return sound_manager->stop(event_instance, FMODStudio::StopMode::AllowFadeOut);
             },
             [](std::monostate)
             { return false; }},
@@ -567,11 +688,12 @@ bool CustomEventInstance::stop()
 }
 bool CustomEventInstance::stop(FMODStudio::StopMode mode)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, mode](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->stop(event_instance, mode);
+                return sound_manager->stop(event_instance, mode);
             },
             [](std::monostate)
             { return false; }},
@@ -579,11 +701,12 @@ bool CustomEventInstance::stop(FMODStudio::StopMode mode)
 }
 std::optional<FMODStudio::PlaybackState> CustomEventInstance::get_playback_state()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->get_playback_state(event_instance);
+                return sound_manager->get_playback_state(event_instance);
             },
             [](std::monostate)
             { return std::optional<FMODStudio::PlaybackState>{}; }},
@@ -591,11 +714,12 @@ std::optional<FMODStudio::PlaybackState> CustomEventInstance::get_playback_state
 }
 bool CustomEventInstance::set_pause(bool pause)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, pause](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_pause(event_instance, pause);
+                return sound_manager->set_pause(event_instance, pause);
             },
             [](std::monostate)
             { return false; }},
@@ -603,11 +727,12 @@ bool CustomEventInstance::set_pause(bool pause)
 }
 std::optional<bool> CustomEventInstance::get_pause()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->get_pause(event_instance);
+                return sound_manager->get_pause(event_instance);
             },
             [](std::monostate)
             { return std::optional<bool>{}; }},
@@ -615,11 +740,12 @@ std::optional<bool> CustomEventInstance::get_pause()
 }
 bool CustomEventInstance::key_off()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->key_off(event_instance);
+                return sound_manager->key_off(event_instance);
             },
             [](std::monostate)
             { return false; }},
@@ -627,11 +753,12 @@ bool CustomEventInstance::key_off()
 }
 bool CustomEventInstance::set_pitch(float pitch)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, pitch](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_pitch(event_instance, pitch);
+                return sound_manager->set_pitch(event_instance, pitch);
             },
             [](std::monostate)
             { return false; }},
@@ -639,11 +766,12 @@ bool CustomEventInstance::set_pitch(float pitch)
 }
 std::optional<float> CustomEventInstance::get_pitch()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->get_pitch(event_instance);
+                return sound_manager->get_pitch(event_instance);
             },
             [](std::monostate)
             { return std::optional<float>{}; }},
@@ -651,11 +779,12 @@ std::optional<float> CustomEventInstance::get_pitch()
 }
 bool CustomEventInstance::set_timeline_position(int position)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, position](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_timeline_position(event_instance, position);
+                return sound_manager->set_timeline_position(event_instance, position);
             },
             [](std::monostate)
             { return false; }},
@@ -663,11 +792,12 @@ bool CustomEventInstance::set_timeline_position(int position)
 }
 std::optional<int> CustomEventInstance::get_timeline_position()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->get_timeline_position(event_instance);
+                return sound_manager->get_timeline_position(event_instance);
             },
             [](std::monostate)
             { return std::optional<int>{}; }},
@@ -675,11 +805,12 @@ std::optional<int> CustomEventInstance::get_timeline_position()
 }
 bool CustomEventInstance::set_volume(float volume)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, volume](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_volume(event_instance, volume);
+                return sound_manager->set_volume(event_instance, volume);
             },
             [](std::monostate)
             { return false; }},
@@ -687,11 +818,12 @@ bool CustomEventInstance::set_volume(float volume)
 }
 std::optional<float> CustomEventInstance::get_volume()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->get_volume(event_instance);
+                return sound_manager->get_volume(event_instance);
             },
             [](std::monostate)
             { return std::optional<float>{}; }},
@@ -699,11 +831,12 @@ std::optional<float> CustomEventInstance::get_volume()
 }
 std::optional<float> CustomEventInstance::get_parameter_by_name(std::string name)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, name](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->get_parameter_by_name(event_instance, name);
+                return sound_manager->get_parameter_by_name(event_instance, name);
             },
             [](std::monostate)
             { return std::optional<float>{}; }},
@@ -711,11 +844,12 @@ std::optional<float> CustomEventInstance::get_parameter_by_name(std::string name
 }
 bool CustomEventInstance::set_parameter_by_name(std::string name, float value)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, name, value](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_parameter_by_name(event_instance, name, value, false);
+                return sound_manager->set_parameter_by_name(event_instance, name, value, false);
             },
             [](std::monostate)
             { return false; }},
@@ -723,11 +857,12 @@ bool CustomEventInstance::set_parameter_by_name(std::string name, float value)
 }
 bool CustomEventInstance::set_parameter_by_name(std::string name, float value, bool ignoreseekspeed)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, name, value, ignoreseekspeed](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_parameter_by_name(event_instance, name, value, ignoreseekspeed);
+                return sound_manager->set_parameter_by_name(event_instance, name, value, ignoreseekspeed);
             },
             [](std::monostate)
             { return false; }},
@@ -735,11 +870,12 @@ bool CustomEventInstance::set_parameter_by_name(std::string name, float value, b
 }
 bool CustomEventInstance::set_parameter_by_name_with_label(std::string name, std::string label)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, name, label](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_parameter_by_name_with_label(event_instance, name, label, false);
+                return sound_manager->set_parameter_by_name_with_label(event_instance, name, label, false);
             },
             [](std::monostate)
             { return false; }},
@@ -747,11 +883,12 @@ bool CustomEventInstance::set_parameter_by_name_with_label(std::string name, std
 }
 bool CustomEventInstance::set_parameter_by_name_with_label(std::string name, std::string label, bool ignoreseekspeed)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, name, label, ignoreseekspeed](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_parameter_by_name_with_label(event_instance, name, label, ignoreseekspeed);
+                return sound_manager->set_parameter_by_name_with_label(event_instance, name, label, ignoreseekspeed);
             },
             [](std::monostate)
             { return false; }},
@@ -759,11 +896,12 @@ bool CustomEventInstance::set_parameter_by_name_with_label(std::string name, std
 }
 std::optional<float> CustomEventInstance::get_parameter_by_id(FMODStudio::ParameterId id)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, id](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->get_parameter_by_id(event_instance, id);
+                return sound_manager->get_parameter_by_id(event_instance, id);
             },
             [](std::monostate)
             { return std::optional<float>{}; }},
@@ -771,11 +909,12 @@ std::optional<float> CustomEventInstance::get_parameter_by_id(FMODStudio::Parame
 }
 bool CustomEventInstance::set_parameter_by_id(FMODStudio::ParameterId id, float value)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, id, value](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_parameter_by_id(event_instance, id, value, false);
+                return sound_manager->set_parameter_by_id(event_instance, id, value, false);
             },
             [](std::monostate)
             { return false; }},
@@ -783,11 +922,12 @@ bool CustomEventInstance::set_parameter_by_id(FMODStudio::ParameterId id, float 
 }
 bool CustomEventInstance::set_parameter_by_id(FMODStudio::ParameterId id, float value, bool ignoreseekspeed)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, id, value, ignoreseekspeed](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_parameter_by_id(event_instance, id, value, ignoreseekspeed);
+                return sound_manager->set_parameter_by_id(event_instance, id, value, ignoreseekspeed);
             },
             [](std::monostate)
             { return false; }},
@@ -795,11 +935,12 @@ bool CustomEventInstance::set_parameter_by_id(FMODStudio::ParameterId id, float 
 }
 bool CustomEventInstance::set_parameter_by_id_with_label(FMODStudio::ParameterId id, std::string label)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, id, label](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_parameter_by_id_with_label(event_instance, id, label, false);
+                return sound_manager->set_parameter_by_id_with_label(event_instance, id, label, false);
             },
             [](std::monostate)
             { return false; }},
@@ -807,11 +948,12 @@ bool CustomEventInstance::set_parameter_by_id_with_label(FMODStudio::ParameterId
 }
 bool CustomEventInstance::set_parameter_by_id_with_label(FMODStudio::ParameterId id, std::string label, bool ignoreseekspeed)
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this, id, label, ignoreseekspeed](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->set_parameter_by_id_with_label(event_instance, id, label, ignoreseekspeed);
+                return sound_manager->set_parameter_by_id_with_label(event_instance, id, label, ignoreseekspeed);
             },
             [](std::monostate)
             { return false; }},
@@ -819,11 +961,12 @@ bool CustomEventInstance::set_parameter_by_id_with_label(FMODStudio::ParameterId
 }
 bool CustomEventInstance::release()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->release(event_instance);
+                return sound_manager->release(event_instance);
             },
             [](std::monostate)
             { return false; }},
@@ -831,11 +974,12 @@ bool CustomEventInstance::release()
 }
 bool CustomEventInstance::is_valid()
 {
+    auto sound_manager = lock_manager(m_SoundManager, m_FmodHandle);
     return std::visit(
         overloaded{
-            [this](FMODStudio::EventInstance* event_instance)
+            [&](FMODStudio::EventInstance* event_instance)
             {
-                return m_SoundManager->event_instance_is_valid(event_instance);
+                return sound_manager->event_instance_is_valid(event_instance);
             },
             [](std::monostate)
             { return false; }},
@@ -851,13 +995,18 @@ FMODguidMap::FMODguidMap(FMODguidMap&& rhs) noexcept
     std::swap(m_GUIDmap, rhs.m_GUIDmap);
     std::swap(m_SoundManager, rhs.m_SoundManager);
 }
-FMODguidMap::FMODguidMap(std::unordered_map<std::string, FMOD::FMOD_GUID> m_GUIDmap, SoundManager* sound_manager)
+FMODguidMap::FMODguidMap(std::unordered_map<std::string, FMOD::FMOD_GUID> m_GUIDmap, std::weak_ptr<SoundManager> sound_manager)
     : m_GUIDmap{m_GUIDmap}, m_SoundManager{sound_manager}
 {
 }
 CustomEventDescription FMODguidMap::get_event(std::string path)
 {
-    return m_SoundManager->guidmap_lookup_id(m_GUIDmap, path);
+    auto sound_manager = m_SoundManager.lock();
+    if (!sound_manager)
+    {
+        return CustomEventDescription{nullptr, nullptr};
+    }
+    return sound_manager->guidmap_lookup_id(m_GUIDmap, path);
 }
 
 struct SoundManager::Sound
@@ -877,11 +1026,12 @@ struct SoundManager::Bank
 SoundManager::SoundManager(DecodeAudioFile* decode_function)
     : m_DecodeFunction{decode_function}
 {
-    m_IsInit = true;
-#define AUDIO_INIT_ERROR(format, ...) \
-    DEBUG(format, __VA_ARGS__);       \
-    // what's the point of this then?
-    // m_IsInit = false;
+// Log init failures but never disable the API on them: the SoundManager is built once, early
+// (Playlunky constructs it during ModManager init, before FMOD's DLLs are necessarily loaded), so
+// a startup race would otherwise kill the whole sound API for the session. Callers guard on the
+// data they actually need instead -- see the null checks in for_each_*/convert_sound_id.
+// Disabling on failure was tried in 485039d5 and deliberately removed in 7aa58d3c.
+#define AUDIO_INIT_ERROR(format, ...) DEBUG(format, __VA_ARGS__)
 
     if (HMODULE fmod_studio = GetModuleHandle("fmodstudio.dll"))
     {
@@ -1044,6 +1194,8 @@ SoundManager::SoundManager(DecodeAudioFile* decode_function)
                 reinterpret_cast<FMODStudio::EventInstanceIsValid*>(GetProcAddress(fmod_studio, "FMOD_Studio_EventInstance_IsValid"));
 
             EventCallbackData::EventInstanceGetDescription = m_EventInstanceGetDescription;
+            EventCallbackData::EventDescriptionSetCallback = m_EventDescriptionSetCallback;
+            EventCallbackData::EventInstanceSetCallback = m_EventInstanceSetCallback;
         }
         else
         {
@@ -1071,6 +1223,7 @@ SoundManager::SoundManager(DecodeAudioFile* decode_function)
         m_ChannelSetVolume = reinterpret_cast<FMOD::ChannelSetVolume*>(GetProcAddress(fmod, "FMOD_Channel_SetVolume"));
         m_ChannelSetMode = reinterpret_cast<FMOD::ChannelSetMode*>(GetProcAddress(fmod, "FMOD_Channel_SetMode"));
         m_ChannelSetCallback = reinterpret_cast<FMOD::ChannelSetCallback*>(GetProcAddress(fmod, "FMOD_Channel_SetCallback"));
+        SoundCallbackData::ChannelSetCallback = m_ChannelSetCallback;
         m_ChannelSetUserData = reinterpret_cast<FMOD::ChannelSetUserData*>(GetProcAddress(fmod, "FMOD_Channel_SetUserData"));
         m_ChannelGetUserData = reinterpret_cast<FMOD::ChannelGetUserData*>(GetProcAddress(fmod, "FMOD_Channel_GetUserData"));
     }
@@ -1083,13 +1236,58 @@ SoundManager::SoundManager(DecodeAudioFile* decode_function)
 }
 SoundManager::~SoundManager()
 {
-    for (Sound& sound : m_SoundStorage)
+    // Detach from FMOD before releasing anything.
+    PendingDetach pending;
     {
-        m_ReleaseSound(sound.fmod_sound);
+        std::lock_guard lock{s_EventCallbacksMutex};
+        // Every handle we owned, not just the ones needing an FMOD detach: an entry whose hook
+        // failed to install has no entry in pending.events, and its ids would leak here.
+        std::vector<FMODStudio::EventDescription*> owned;
+        for (EventCallbackData& data : s_EventCallbacks)
+        {
+            if (data.owner == this)
+            {
+                owned.push_back(data.handle);
+                collect_event_detach(data, pending);
+            }
+        }
+        std::erase_if(s_EventCallbacks, [this](const EventCallbackData& data)
+                      { return data.owner == this; });
+        std::erase_if(s_EventCallbackIdToEventDescription, [&owned](const auto& kv)
+                      { return std::find(owned.begin(), owned.end(), kv.second) != owned.end(); });
     }
-    for (Bank& bank : m_BankStorage)
+    apply_event_detach(pending);
+
+    std::vector<FMOD::Channel*> channels;
     {
-        m_BankUnload(bank.fmod_bank);
+        std::lock_guard lock{s_SoundCallbacksMutex};
+        for (SoundCallbackData& data : s_SoundCallbacks)
+        {
+            channels.push_back(data.handle);
+        }
+        s_SoundCallbacks.clear();
+    }
+    if (SoundCallbackData::ChannelSetCallback != nullptr)
+    {
+        for (FMOD::Channel* channel : channels)
+        {
+            SoundCallbackData::ChannelSetCallback(channel, nullptr);
+        }
+    }
+
+    if (m_ReleaseSound != nullptr)
+    {
+        for (Sound& sound : m_SoundStorage)
+        {
+            m_ReleaseSound(sound.fmod_sound);
+        }
+    }
+    if (m_BankUnload != nullptr)
+    {
+        for (Bank& bank : m_BankStorage)
+        {
+            m_BankUnload(bank.fmod_bank);
+        }
     }
 }
 
@@ -1100,7 +1298,7 @@ CustomSound SoundManager::get_sound(std::string path)
     if (it != m_SoundStorage.end())
     {
         it->ref_count++;
-        return CustomSound{it->fmod_sound, this};
+        return CustomSound{it->fmod_sound, weak_from_this()};
     }
 
     DecodedAudioBuffer buffer;
@@ -1155,7 +1353,7 @@ CustomSound SoundManager::get_sound(std::string path)
     }
 
     m_SoundStorage.push_back(std::move(new_sound));
-    return CustomSound{m_SoundStorage.back().fmod_sound, this};
+    return CustomSound{m_SoundStorage.back().fmod_sound, weak_from_this()};
 }
 CustomSound SoundManager::get_sound(const char* path)
 {
@@ -1168,7 +1366,7 @@ CustomSound SoundManager::get_existing_sound(std::string_view path)
     if (it != m_SoundStorage.end())
     {
         it->ref_count++;
-        return CustomSound{it->fmod_sound, this};
+        return CustomSound{it->fmod_sound, weak_from_this()};
     }
     return CustomSound{nullptr, nullptr};
 }
@@ -1209,7 +1407,7 @@ PlayingSound SoundManager::play_sound(FMOD::Sound* fmod_sound, bool paused, bool
 {
     FMOD::Channel* channel{nullptr};
     m_PlaySound(m_FmodSystem, fmod_sound, as_music ? m_MusicChannelGroup : m_SfxChannelGroup, paused, &channel);
-    return PlayingSound{channel, this};
+    return PlayingSound{channel, weak_from_this()};
 }
 
 CustomSound SoundManager::get_event(std::string_view event_name)
@@ -1217,7 +1415,7 @@ CustomSound SoundManager::get_event(std::string_view event_name)
     auto it = m_SoundData.NameToEvent.find(event_name);
     if (it != m_SoundData.NameToEvent.end())
     {
-        return CustomSound{it->second->Event, this};
+        return CustomSound{it->second->Event, weak_from_this()};
     }
     return CustomSound{nullptr, nullptr};
 }
@@ -1229,7 +1427,7 @@ PlayingSound SoundManager::play_event(FMODStudio::EventDescription* fmod_event, 
     {
         m_EventInstanceStart(instance);
     }
-    return PlayingSound{instance, this};
+    return PlayingSound{instance, weak_from_this()};
 }
 
 CustomBank SoundManager::load_bank(std::string path, FMODStudio::LoadBankFlags flags)
@@ -1238,7 +1436,7 @@ CustomBank SoundManager::load_bank(std::string path, FMODStudio::LoadBankFlags f
                            { return bank.path == path; });
     if (it != m_BankStorage.end())
     {
-        return CustomBank{it->fmod_bank, this};
+        return CustomBank{it->fmod_bank, weak_from_this()};
     }
 
     Bank new_bank;
@@ -1252,7 +1450,7 @@ CustomBank SoundManager::load_bank(std::string path, FMODStudio::LoadBankFlags f
     }
 
     m_BankStorage.push_back(std::move(new_bank));
-    return CustomBank{m_BankStorage.back().fmod_bank, this};
+    return CustomBank{m_BankStorage.back().fmod_bank, weak_from_this()};
 }
 CustomBank SoundManager::load_bank(const char* path, FMODStudio::LoadBankFlags flags)
 {
@@ -1264,7 +1462,7 @@ CustomBank SoundManager::get_existing_bank(std::string_view path)
                            { return bank.path == path; });
     if (it != m_BankStorage.end())
     {
-        return CustomBank{it->fmod_bank, this};
+        return CustomBank{it->fmod_bank, weak_from_this()};
     }
     return CustomBank{nullptr, nullptr};
 }
@@ -1370,7 +1568,7 @@ FMODguidMap SoundManager::create_fmod_guid_map(std::string_view path)
         }
         if (!newmap.empty())
         {
-            return FMODguidMap{newmap, this};
+            return FMODguidMap{newmap, weak_from_this()};
         }
     }
     DEBUG("Failed to create FMOD GUID map.");
@@ -1412,7 +1610,7 @@ CustomEventDescription SoundManager::get_event_by_id(FMODStudio::FMOD_GUID* guid
     FMODStudio::EventDescription* fmod_event;
     if (FMOD_CHECK_CALL(m_SystemGetEventByID(m_FmodStudioSystem, guid, &fmod_event)))
     {
-        return CustomEventDescription{fmod_event, this};
+        return CustomEventDescription{fmod_event, weak_from_this()};
     }
     DEBUG("Could not get event or snapshot for GUID {{{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}}}", guid->Data1, guid->Data2, guid->Data3, guid->Data4[0], guid->Data4[1], guid->Data4[2], guid->Data4[3], guid->Data4[4], guid->Data4[5], guid->Data4[6], guid->Data4[7]);
     return CustomEventDescription{nullptr, nullptr};
@@ -1422,7 +1620,7 @@ std::shared_ptr<CustomEventInstance> SoundManager::event_description_create_inst
 {
     FMODStudio::EventInstance* instance{nullptr};
     m_EventCreateInstance(fmod_event, &instance);
-    return std::make_shared<CustomEventInstance>(instance, this);
+    return std::make_shared<CustomEventInstance>(instance, weak_from_this());
 }
 bool SoundManager::event_description_release_all_instances(FMODStudio::EventDescription* fmod_event)
 {
@@ -1745,7 +1943,7 @@ bool SoundManager::set_callback(PlayingSound playing_sound, SoundCallbackFunctio
                 }
                 else
                 {
-                    s_EventCallbacks.push_back(EventCallbackData{event, {}, {{*instance, std::move(callback)}}, this});
+                    s_EventCallbacks.push_back(EventCallbackData{event, {}, {{*instance, std::move(callback)}}, this, weak_from_this()});
                 }
                 return true;
             }
@@ -1756,7 +1954,13 @@ bool SoundManager::set_callback(PlayingSound playing_sound, SoundCallbackFunctio
 
 std::uint32_t SoundManager::set_callback(std::string_view event_name, EventCallbackFunction callback, FMODStudio::EventCallbackType types)
 {
-    return set_callback(m_SoundData.NameToEvent[event_name]->Event, std::move(callback), types);
+    auto it = m_SoundData.NameToEvent.find(event_name);
+    if (it == m_SoundData.NameToEvent.end() || it->second == nullptr)
+    {
+        DEBUG("Trying to set a callback for unknown sound '{}'...", event_name);
+        return INVALID_SOUND_CALLBACK_ID;
+    }
+    return set_callback(it->second->Event, std::move(callback), types);
 }
 std::uint32_t
 SoundManager::set_callback(FMODStudio::EventDescription* fmod_event, EventCallbackFunction callback, FMODStudio::EventCallbackType types)
@@ -1765,11 +1969,27 @@ SoundManager::set_callback(FMODStudio::EventDescription* fmod_event, EventCallba
     auto it = std::find_if(
         s_EventCallbacks.begin(), s_EventCallbacks.end(), [fmod_event](const EventCallbackData& _callback)
         { return _callback.handle == fmod_event; });
-    if (it == s_EventCallbacks.end())
+    const bool created_entry = it == s_EventCallbacks.end();
+    if (created_entry)
     {
-        s_EventCallbacks.push_back(EventCallbackData{fmod_event, {}, {}, this});
+        s_EventCallbacks.push_back(EventCallbackData{fmod_event, {}, {}, this, weak_from_this()});
         it = s_EventCallbacks.end() - 1;
-        FMOD_CHECK_CALL(m_EventDescriptionSetCallback(fmod_event, &EventInstanceCallback, FMODStudio::EventCallbackType::All));
+    }
+    // Keyed on the flag rather than on the entry existing: an entry created by
+    // set_callback(PlayingSound, ...) hooks only instances, so without this the description
+    // callback would never be installed and these callbacks would never fire.
+    if (!it->description_callback_installed)
+    {
+        if (!FMOD_CHECK_CALL(m_EventDescriptionSetCallback(fmod_event, &EventInstanceCallback, FMODStudio::EventCallbackType::All)))
+        {
+            // Nothing will ever call us back, so don't hand out an id that looks live.
+            if (created_entry)
+            {
+                s_EventCallbacks.pop_back();
+            }
+            return INVALID_SOUND_CALLBACK_ID;
+        }
+        it->description_callback_installed = true;
     }
 
     std::uint32_t callback_id = current_callback_id++;
@@ -1787,21 +2007,43 @@ SoundManager::set_callback(FMODStudio::EventDescription* fmod_event, EventCallba
 }
 void SoundManager::clear_callback(std::uint32_t id)
 {
-    std::lock_guard lock{s_EventCallbacksMutex};
-    FMODStudio::EventDescription* fmod_event = s_EventCallbackIdToEventDescription[id];
-    auto it = std::find_if(
-        s_EventCallbacks.begin(), s_EventCallbacks.end(), [fmod_event](const EventCallbackData& callback)
-        { return callback.handle == fmod_event; });
-    if (it != s_EventCallbacks.end())
+    PendingDetach pending;
     {
+        std::lock_guard lock{s_EventCallbacksMutex};
+
+        // find(), not operator[]: an unknown id would otherwise be inserted mapping to nullptr.
+        auto id_it = s_EventCallbackIdToEventDescription.find(id);
+        if (id_it == s_EventCallbackIdToEventDescription.end())
+        {
+            return;
+        }
+        FMODStudio::EventDescription* fmod_event = id_it->second;
+        s_EventCallbackIdToEventDescription.erase(id_it);
+
+        auto it = std::find_if(
+            s_EventCallbacks.begin(), s_EventCallbacks.end(), [fmod_event](const EventCallbackData& callback)
+            { return callback.handle == fmod_event; });
+        if (it == s_EventCallbacks.end())
+        {
+            return;
+        }
+
         for (auto& [type, cbs] : it->callbacks)
         {
             cbs.erase(std::remove_if(cbs.begin(), cbs.end(), [id](const EventCallbackData::Callback& cb)
                                      { return cb.id == id; }),
                       cbs.end());
         }
+
+        const bool any_left = std::any_of(it->callbacks.begin(), it->callbacks.end(), [](const auto& kv)
+                                          { return !kv.second.empty(); });
+        if (!any_left && it->specific_callbacks.empty())
+        {
+            collect_event_detach(*it, pending);
+            s_EventCallbacks.erase(it);
+        }
     }
-    s_EventCallbackIdToEventDescription.erase(id);
+    apply_event_detach(pending);
 }
 
 std::unordered_map<VANILLA_SOUND_PARAM, const char*> SoundManager::get_parameters(PlayingSound playing_sound)
@@ -1824,7 +2066,7 @@ std::unordered_map<VANILLA_SOUND_PARAM, const char*> SoundManager::get_parameter
 }
 std::unordered_map<VANILLA_SOUND_PARAM, const char*> SoundManager::get_parameters(FMODStudio::EventDescription* fmod_event)
 {
-    if (const EventDescription* event = m_SoundData.FmodEventToEvent[fmod_event])
+    if (const EventDescription* event = find_event_description(fmod_event))
     {
         std::unordered_map<VANILLA_SOUND_PARAM, const char*> parameters;
         for (size_t i = 0; i < m_SoundData.Parameters->ParameterNames.size(); i++)
@@ -1848,7 +2090,7 @@ std::optional<float> SoundManager::get_parameter(PlayingSound playing_sound, VAN
                        FMODStudio::EventDescription* event;
                        if (FMOD_CHECK_CALL(m_EventInstanceGetDescription(instance, &event)))
                        {
-                           if (const EventDescription* event_desc = m_SoundData.FmodEventToEvent[event])
+                           if (const EventDescription* event_desc = find_event_description(event))
                            {
                                float value;
                                if (event_desc->HasParameter[parameter_index] &&
@@ -1875,7 +2117,7 @@ bool SoundManager::set_parameter(PlayingSound playing_sound, VANILLA_SOUND_PARAM
                        FMODStudio::EventDescription* event;
                        if (FMOD_CHECK_CALL(m_EventInstanceGetDescription(instance, &event)))
                        {
-                           if (const EventDescription* event_desc = m_SoundData.FmodEventToEvent[event])
+                           if (const EventDescription* event_desc = find_event_description(event))
                            {
                                return event_desc->HasParameter[parameter_index] &&
                                       FMOD_CHECK_CALL(
@@ -1891,6 +2133,9 @@ bool SoundManager::set_parameter(PlayingSound playing_sound, VANILLA_SOUND_PARAM
 
 SOUNDID SoundManager::convert_sound_id(const VANILLA_SOUND& s_name)
 {
+    if (m_SoundData.Events == nullptr)
+        return -1;
+
     for (auto& [id, event_descr] : *m_SoundData.Events)
         if (event_descr.Name == s_name)
             return id;
@@ -1905,7 +2150,7 @@ const VANILLA_SOUND& SoundManager::convert_sound_id(SOUNDID sound_id)
     // if (event == m_SoundData.Events->end())
     //    return empty;
     // return event->second.Name;
-    if (sound_id < 0)
+    if (sound_id < 0 || m_SoundData.Events == nullptr)
         return empty;
 
     for (auto& [id, event_descr] : *m_SoundData.Events)
@@ -1933,26 +2178,6 @@ SoundMeta* play_sound(SOUNDID sound_id, uint32_t source_uid)
             source->set_as_sound_source(sound_info);
     }
     return sound_info;
-}
-
-SoundManager* g_sound_manager{nullptr};
-
-SoundMeta* play_sound(VANILLA_SOUND sound, uint32_t source_uid)
-{
-    if (g_sound_manager == nullptr)
-        g_sound_manager = new SoundManager(nullptr);
-
-    auto sound_id = g_sound_manager->convert_sound_id(sound);
-    return play_sound(sound_id, source_uid);
-}
-
-SoundMeta* construct_soundmeta(VANILLA_SOUND sound, bool background_sound)
-{
-    if (g_sound_manager == nullptr)
-        g_sound_manager = new SoundManager(nullptr);
-
-    auto sound_id = g_sound_manager->convert_sound_id(sound);
-    return construct_soundmeta(sound_id, background_sound);
 }
 
 SoundMeta* construct_soundmeta(SOUNDID sound_id, bool background_sound)

--- a/src/game_api/sound_manager.hpp
+++ b/src/game_api/sound_manager.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <functional>
 #include <list>
+#include <memory>
 #include <new>
 #include <optional>
 #include <string>
@@ -26,6 +27,10 @@ class CustomEventInstance;
 
 using SoundCallbackFunction = std::function<void()>;
 using EventCallbackFunction = std::function<void(PlayingSound)>;
+
+/// Returned by SoundManager::set_callback when the callback could not be registered,
+/// e.g. because the event name does not exist. Valid callback ids start at 1.
+inline constexpr std::uint32_t INVALID_SOUND_CALLBACK_ID{0};
 
 enum class SOUND_LOOP_MODE
 {
@@ -53,7 +58,7 @@ class CustomSound
 
     operator bool()
     {
-        return m_SoundManager != nullptr;
+        return !m_SoundManager.expired();
     }
 
     PlayingSound play();
@@ -66,11 +71,11 @@ class CustomSound
     CustomSound(std::nullptr_t, std::nullptr_t)
     {
     }
-    CustomSound(FMOD::Sound* fmod_sound, SoundManager* sound_manager);
-    CustomSound(FMODStudio::EventDescription* fmod_event, SoundManager* sound_manager);
+    CustomSound(FMOD::Sound* fmod_sound, std::weak_ptr<SoundManager> sound_manager);
+    CustomSound(FMODStudio::EventDescription* fmod_event, std::weak_ptr<SoundManager> sound_manager);
 
     std::variant<FMOD::Sound*, FMODStudio::EventDescription*, std::monostate> m_FmodHandle{};
-    SoundManager* m_SoundManager{nullptr};
+    std::weak_ptr<SoundManager> m_SoundManager;
 };
 
 using PlayingSoundHandle = std::variant<FMOD::Channel*, FMODStudio::EventInstance*, std::monostate>;
@@ -105,11 +110,11 @@ class PlayingSound
     PlayingSound(std::nullptr_t, std::nullptr_t)
     {
     }
-    PlayingSound(FMOD::Channel* fmod_channel, SoundManager* sound_manager);
-    PlayingSound(FMODStudio::EventInstance* fmod_event, SoundManager* sound_manager);
+    PlayingSound(FMOD::Channel* fmod_channel, std::weak_ptr<SoundManager> sound_manager);
+    PlayingSound(FMODStudio::EventInstance* fmod_event, std::weak_ptr<SoundManager> sound_manager);
 
     PlayingSoundHandle m_FmodHandle{};
-    SoundManager* m_SoundManager{nullptr};
+    std::weak_ptr<SoundManager> m_SoundManager;
 };
 
 class CustomBank
@@ -125,7 +130,7 @@ class CustomBank
 
     operator bool()
     {
-        return m_SoundManager != nullptr;
+        return !m_SoundManager.expired();
     }
 
     std::optional<FMODStudio::LoadingState> get_loading_state();
@@ -139,15 +144,16 @@ class CustomBank
     CustomBank(std::nullptr_t, std::nullptr_t)
     {
     }
-    CustomBank(FMOD::Bank* fmod_bank, SoundManager* sound_manager);
+    CustomBank(FMOD::Bank* fmod_bank, std::weak_ptr<SoundManager> sound_manager);
 
     std::variant<FMOD::Bank*, std::monostate> m_FmodHandle{};
-    SoundManager* m_SoundManager{nullptr};
+    std::weak_ptr<SoundManager> m_SoundManager;
 };
 
 class CustomEventDescription
 {
     friend class SoundManager;
+    friend class FMODguidMap;
 
   public:
     CustomEventDescription(const CustomEventDescription& rhs);
@@ -158,7 +164,7 @@ class CustomEventDescription
 
     operator bool()
     {
-        return m_SoundManager != nullptr;
+        return !m_SoundManager.expired();
     }
 
     std::shared_ptr<CustomEventInstance> create_instance();
@@ -179,10 +185,10 @@ class CustomEventDescription
     CustomEventDescription(std::nullptr_t, std::nullptr_t)
     {
     }
-    CustomEventDescription(FMODStudio::EventDescription* fmod_event, SoundManager* sound_manager);
+    CustomEventDescription(FMODStudio::EventDescription* fmod_event, std::weak_ptr<SoundManager> sound_manager);
 
     std::variant<FMODStudio::EventDescription*, std::monostate> m_FmodHandle{};
-    SoundManager* m_SoundManager{nullptr};
+    std::weak_ptr<SoundManager> m_SoundManager;
 };
 
 using CustomEventInstanceHandle = std::variant<FMODStudio::EventInstance*, std::monostate>;
@@ -195,11 +201,12 @@ class CustomEventInstance
     CustomEventInstance(std::nullptr_t, std::nullptr_t)
     {
     }
-    CustomEventInstance(FMODStudio::EventInstance* fmod_event, SoundManager* sound_manager);
-    CustomEventInstance(const CustomEventInstance& rhs) = default;
-    CustomEventInstance(CustomEventInstance&& rhs) noexcept = default;
-    CustomEventInstance& operator=(const CustomEventInstance& rhs) = default;
-    CustomEventInstance& operator=(CustomEventInstance&& rhs) noexcept = default;
+    CustomEventInstance(FMODStudio::EventInstance* fmod_event, std::weak_ptr<SoundManager> sound_manager);
+    // Non-copyable: the destructor releases the FMOD event instance, so a copy would release twice.
+    CustomEventInstance(const CustomEventInstance& rhs) = delete;
+    CustomEventInstance& operator=(const CustomEventInstance& rhs) = delete;
+    CustomEventInstance(CustomEventInstance&& rhs) noexcept;
+    CustomEventInstance& operator=(CustomEventInstance&& rhs) noexcept;
     ~CustomEventInstance();
 
     bool start();
@@ -233,7 +240,7 @@ class CustomEventInstance
 
   private:
     CustomEventInstanceHandle m_FmodHandle{};
-    SoundManager* m_SoundManager{nullptr};
+    std::weak_ptr<SoundManager> m_SoundManager;
 };
 
 class FMODguidMap
@@ -249,7 +256,7 @@ class FMODguidMap
 
     operator bool()
     {
-        return m_SoundManager != nullptr;
+        return !m_SoundManager.expired();
     }
 
     CustomEventDescription get_event(std::string path);
@@ -258,13 +265,16 @@ class FMODguidMap
     FMODguidMap(std::nullptr_t, std::nullptr_t)
     {
     }
-    FMODguidMap(std::unordered_map<std::string, FMOD::FMOD_GUID> m_GUIDmap, SoundManager* sound_manager);
+    FMODguidMap(std::unordered_map<std::string, FMOD::FMOD_GUID> m_GUIDmap, std::weak_ptr<SoundManager> sound_manager);
 
     std::unordered_map<std::string, FMOD::FMOD_GUID> m_GUIDmap;
-    SoundManager* m_SoundManager{nullptr};
+    std::weak_ptr<SoundManager> m_SoundManager;
 };
 
-class SoundManager
+// Must be owned by a shared_ptr: handles hold a weak_ptr obtained via weak_from_this(), so that a
+// handle outliving the manager (Lua userdata is finalized at ~sol::state, long after a host like
+// Playlunky destroys the manager) fails safely instead of calling into freed memory.
+class SoundManager : public std::enable_shared_from_this<SoundManager>
 {
   public:
     SoundManager(DecodeAudioFile* decode_function);
@@ -274,11 +284,6 @@ class SoundManager
     SoundManager(SoundManager&&) = delete;
     SoundManager& operator=(const SoundManager&) = delete;
     SoundManager& operator=(SoundManager&&) = delete;
-
-    bool is_init() const
-    {
-        return m_IsInit;
-    }
 
     CustomBank load_bank(std::string path, FMODStudio::LoadBankFlags flags);
     CustomBank load_bank(const char* path, FMODStudio::LoadBankFlags flags);
@@ -361,6 +366,10 @@ class SoundManager
     template <class FunT>
     void for_each_event_name(FunT&& fun)
     {
+        if (m_SoundData.Events == nullptr)
+        {
+            return;
+        }
         for (const auto& [id, event] : *m_SoundData.Events)
         {
             fun(event.Name);
@@ -369,6 +378,10 @@ class SoundManager
     template <class FunT>
     void for_each_parameter_name(FunT&& fun)
     {
+        if (m_SoundData.Parameters == nullptr)
+        {
+            return;
+        }
         for (size_t i = 0; i < m_SoundData.Parameters->ParameterNames.size(); i++)
         {
             const auto& parameter_name = m_SoundData.Parameters->ParameterNames[i];
@@ -379,8 +392,6 @@ class SoundManager
     const VANILLA_SOUND& convert_sound_id(SOUNDID id);
 
   private:
-    bool m_IsInit{false};
-
     DecodeAudioFile* m_DecodeFunction{nullptr};
 
     FMOD::System* m_FmodSystem{nullptr};
@@ -475,13 +486,21 @@ class SoundManager
     using EventMap = std::unordered_map<EventId, EventDescription>;
     struct SoundData
     {
-        const EventParameters* Parameters;
-        const EventMap* Events;
+        const EventParameters* Parameters{nullptr};
+        const EventMap* Events{nullptr};
         std::unordered_map<const FMODStudio::EventDescription*, const EventDescription*> FmodEventToEvent;
         std::unordered_map<std::string_view, const EventDescription*> NameToEvent;
     };
     static_assert(sizeof(EventDescription) == 0x1a0);
     SoundData m_SoundData;
+
+    // Must be a const lookup: these run on the FMOD callback thread, and unordered_map::operator[]
+    // would insert on a miss (which custom-bank events always are) while the main thread reads.
+    const EventDescription* find_event_description(const FMODStudio::EventDescription* fmod_event) const
+    {
+        auto it = m_SoundData.FmodEventToEvent.find(fmod_event);
+        return it == m_SoundData.FmodEventToEvent.end() ? nullptr : it->second;
+    }
 
     struct Sound;
     struct Bank;
@@ -535,12 +554,18 @@ struct BackgroundSound : public SoundMeta
     bool destroy_sound; // don't use directly, use the kill function
 };
 
-SoundMeta* play_sound(VANILLA_SOUND sound, uint32_t source_uid);
 SoundMeta* play_sound(SOUNDID sound_id, uint32_t source_uid);
+/*
+// Bound in sound_lua.cpp as a lambda since resolving the name needs a SoundManager, so there is no
+// C++ declaration to scan. This one is here purely for the autodoc.
+SoundMeta* play_sound(VANILLA_SOUND sound, uint32_t source_uid);
+*/
 
 // could probably be exposed if someone can actually figure out how to properly "register it"?
 // it probably also needs to make sure the lua owns the returned object and it will properly delete it
-SoundMeta* construct_soundmeta(VANILLA_SOUND sound, bool background_sound);
+// If you do expose it and want to take a VANILLA_SOUND name, convert it to a SOUNDID at the Lua
+// boundary via backend->sound_manager (see how play_sound does it in sound_lua.cpp). Converting a
+// name needs a SoundManager, so do not reintroduce a global one to do it here.
 SoundMeta* construct_soundmeta(SOUNDID sound_id, bool background_sound);
 /*
 VANILLA_SOUND convert_sound_id(SOUNDID id); // for the autodoc

--- a/src/info_dump/main.cpp
+++ b/src/info_dump/main.cpp
@@ -1243,11 +1243,11 @@ void run()
         }
     }
 
-    SoundManager sound_mgr(nullptr);
+    auto sound_mgr = std::make_shared<SoundManager>(nullptr);
 
     if (auto file = std::ofstream("game_data/vanilla_sounds.txt"))
     {
-        sound_mgr.for_each_event_name(
+        sound_mgr->for_each_event_name(
             [&file](std::string event_name)
             {
                 std::string clean_event_name = event_name;
@@ -1261,7 +1261,7 @@ void run()
 
     if (auto file = std::ofstream("game_data/vanilla_sound_params.txt"))
     {
-        sound_mgr.for_each_parameter_name(
+        sound_mgr->for_each_parameter_name(
             [&file](std::string parameter_name, std::uint32_t id)
             {
                 std::transform(parameter_name.begin(), parameter_name.end(), parameter_name.begin(), [](unsigned char c)
@@ -1281,7 +1281,7 @@ void run()
 
     if (auto file = std::ofstream("game_data/lua_enums.txt"))
     {
-        SpelunkyConsole api_gen_script(&sound_mgr);
+        SpelunkyConsole api_gen_script(sound_mgr.get());
         file << api_gen_script.dump_api() << std::endl;
         // file << "---@diagnostic disable: lowercase-global,deprecated" << std::endl;
     }

--- a/src/injected/ui.cpp
+++ b/src/injected/ui.cpp
@@ -73,7 +73,7 @@ std::wstring_convert<cvt_type, wchar_t> cvt;
 template <class T>
 concept Script = std::is_same_v<T, SpelunkyConsole> || std::is_same_v<T, SpelunkyScript>;
 
-std::unique_ptr<SoundManager> g_SoundManager;
+std::shared_ptr<SoundManager> g_SoundManager;
 
 std::unique_ptr<SpelunkyConsole> g_Console;
 std::deque<ScriptMessage> g_ConsoleMessages;
@@ -10019,7 +10019,7 @@ std::string make_save_path(std::string_view script_path, std::string_view script
 
 void init_ui(ImGuiContext* ctx)
 {
-    g_SoundManager = std::make_unique<SoundManager>(&LoadAudioFile);
+    g_SoundManager = std::make_shared<SoundManager>(&LoadAudioFile);
 
     API::init(g_SoundManager.get());
     API::post_init();

--- a/src/spel2_dll/spel2.cpp
+++ b/src/spel2_dll/spel2.cpp
@@ -17,8 +17,9 @@
 #include "window_api.hpp"
 
 #include <cstring>
+#include <memory>
 
-SoundManager* g_SoundManager{nullptr};
+std::shared_ptr<SoundManager> g_SoundManager;
 SpelunkyConsole* g_Console{nullptr};
 
 void Spelunky_SetDoHooks(bool do_hooks)
@@ -53,7 +54,7 @@ void Spelunky_InitSwapChainHooks(IDXGISwapChain* swap_chain)
 void Spelunky_InitSoundManager(Spelunky_DecodeAudioFile decode_function)
 {
     static Spelunky_DecodeAudioFile local_decode_function = decode_function;
-    g_SoundManager = new SoundManager(
+    g_SoundManager = std::make_shared<SoundManager>(
         [](const char* file_path)
         {
             Spelunky_DecodedAudioBuffer buffer = local_decode_function(file_path);
@@ -68,11 +69,7 @@ void Spelunky_InitSoundManager(Spelunky_DecodeAudioFile decode_function)
 }
 void Spelunky_DestroySoundManager()
 {
-    if (g_SoundManager != nullptr)
-    {
-        delete g_SoundManager;
-        g_SoundManager = nullptr;
-    }
+    g_SoundManager.reset();
 }
 
 void Spelunky_ShowCursor()
@@ -202,7 +199,7 @@ SpelunkyScript* Spelunky_CreateScript(const char* file_path, bool enabled)
     std::string code = read_whole_file(file_path);
     if (!code.empty())
     {
-        return new SpelunkyScript(std::move(code), file_path, g_SoundManager, g_Console, enabled);
+        return new SpelunkyScript(std::move(code), file_path, g_SoundManager.get(), g_Console, enabled);
     }
     return nullptr;
 }
@@ -277,7 +274,7 @@ SpelunkyConsole* CreateConsole()
 {
     if (g_Console == nullptr)
     {
-        g_Console = new SpelunkyConsole(g_SoundManager);
+        g_Console = new SpelunkyConsole(g_SoundManager.get());
     }
     return g_Console;
 }


### PR DESCRIPTION
Sound handles given to Lua held a raw SoundManager*. The manager dies before the Lua state does, so anything still alive in Lua could call into freed memory on shutdown.

Updated handles to hold a weak_ptr and lock it per call. If the manager is gone the handle degrades to monostate and the existing failure branch runs. SoundManager is owned by a shared_ptr everywhere it gets created.

Other fixes:

- ~SoundManager left its callbacks installed on the game's FMOD event descriptions. The game keeps running after we go away, so FMOD could call into a dead manager.
- clear_vanilla_sound_callback never unregistered from FMOD or dropped its s_EventCallbacks entry, so that vector grew forever during play.
- A vanilla sound callback never fired if a PlayingSound callback had been set on the same event first.
- set_vanilla_sound_callback null-derefed on an unknown name and left a dangling string_view key behind.
- PlayingSound get/set_parameter inserted into FmodEventToEvent from the FMOD callback thread while the main thread read it.
- play_sound(VANILLA_SOUND) built and leaked a second SoundManager.
- m_SoundData pointers were left uninitialized when FMOD wasn't found.

Removed m_IsInit. It was always true, and the line that set it false was removed in 7aa58d3c for killing the whole sound API. The null checks cover that now.

~CustomSound still calls acquire_sound instead of release_sound. That one changes when sounds actually get freed so I didn't want to bundle it in this change.