### PR TITLE
Sandbox hardening

### DIFF
--- a/src/game_api/lua_libs/lua_libs.cpp
+++ b/src/game_api/lua_libs/lua_libs.cpp
@@ -935,8 +935,13 @@ local function s(t, opts)
 end
 
 local function deserialize(data, opts)
-  local env = (opts and opts.safe == false) and G
-    or setmetatable({}, {
+  -- Overlunky: upstream passed the chunk the real global table when opts.safe is false.
+  -- This would allow escaping the sandbox. Raise an error explaining that it is not allowed.
+
+  if opts and opts.safe == false then
+    error("serpent: safe=false is disabled in Overlunky.", 2)
+  end
+  local env = setmetatable({}, {
         __index = function(t,k) return t end,
         __call = function(t,...) error("cannot call functions") end
       })

--- a/src/game_api/script/lua_backend.cpp
+++ b/src/game_api/script/lua_backend.cpp
@@ -37,6 +37,8 @@
 #include "window_api.hpp"             // for get_window
 
 std::vector<std::unique_ptr<LuaBackend::ProtectedBackend>> g_all_backends;
+/// Identity of a running script, keyed on its environment table.
+std::unordered_map<const void*, LuaBackend*> g_backend_envs;
 std::unordered_map<int, HotKey> g_hotkeys;
 int g_hotkey_count = 0;
 
@@ -60,6 +62,7 @@ LuaBackend::LuaBackend(SoundManager* sound_mgr, LuaConsole* con)
     std::lock_guard lock{global_lua_lock};
     g_all_backends.emplace_back(new ProtectedBackend{this});
     self = g_all_backends.back().get();
+    g_backend_envs[lua.pointer()] = this;
 }
 LuaBackend::~LuaBackend()
 {
@@ -78,6 +81,7 @@ LuaBackend::~LuaBackend()
 
     {
         std::lock_guard lock{global_lua_lock};
+        g_backend_envs.erase(lua.pointer());
         std::erase_if(g_all_backends, [this](const std::unique_ptr<ProtectedBackend>& protected_backend)
                       { return protected_backend.get() == self; });
     }
@@ -1661,7 +1665,12 @@ void LuaBackend::for_each_backend(std::function<bool(LockedBackend)> fun, bool s
 }
 LuaBackend::LockedBackend LuaBackend::get_backend(std::string_view id)
 {
-    return get_backend_safe(id).value();
+    auto backend = get_backend_safe(id);
+    if (!backend)
+    {
+        throw std::runtime_error{fmt::format("No script backend for '{}'", id)};
+    }
+    return std::move(backend).value();
 }
 std::optional<LuaBackend::LockedBackend> LuaBackend::get_backend_safe(std::string_view id)
 {
@@ -1718,19 +1727,34 @@ std::string LuaBackend::get_calling_backend_id()
     }
 
     static const sol::state& lua = get_lua_vm();
-    auto get_script_id = lua["get_script_id"];
-    if (get_script_id.get_type() == sol::type::function)
+    auto get_script_envs = lua["__get_script_envs"];
+    if (get_script_envs.get_type() == sol::type::function)
     {
-        auto script_id = get_script_id();
-        if (script_id.get_type() == sol::type::string && script_id.valid())
+        auto script_envs = get_script_envs();
+        if (!script_envs.valid())
         {
-            return script_id.get<std::string>();
-        }
-        else
-        {
-            sol::error e = script_id;
+            sol::error e = script_envs;
             throw std::runtime_error{e.what()};
         }
+        if (script_envs.get_type() == sol::type::table)
+        {
+            // Identify the caller by which environment table it is running in.
+            sol::table envs = script_envs;
+            for (std::size_t i = 1; i <= envs.size(); ++i)
+            {
+                sol::object env = envs[i];
+                if (env.get_type() != sol::type::table)
+                {
+                    continue;
+                }
+                auto it = g_backend_envs.find(env.as<sol::table>().pointer());
+                if (it != g_backend_envs.end())
+                {
+                    return it->second->get_path();
+                }
+            }
+        }
+        throw std::runtime_error{"Could not identify the calling script."};
     }
 
     throw std::runtime_error{"Trying to get calling backend but Lua state does not seem to be setup..."};

--- a/src/game_api/script/lua_console.cpp
+++ b/src/game_api/script/lua_console.cpp
@@ -1066,7 +1066,7 @@ void LuaConsole::push_history(std::string history_item, std::vector<ScriptMessag
 
 std::string LuaConsole::dump_api()
 {
-    std::set<std::string> excluded_keys{"meta", "__require", "__script_id", "TYPE_MAP", "get_script_id"};
+    std::set<std::string> excluded_keys{"meta", "__require", "__loadlib", "__load", "__loadfile", "__get_script_env", "__script_id", "TYPE_MAP", "get_script_id"};
 
     sol::state dummy_state;
     dummy_state.open_libraries(sol::lib::math, sol::lib::base, sol::lib::string, sol::lib::table, sol::lib::coroutine, sol::lib::package, sol::lib::debug);

--- a/src/game_api/script/lua_require.cpp
+++ b/src/game_api/script/lua_require.cpp
@@ -1,6 +1,7 @@
 #include "lua_require.hpp"
 
 #include <algorithm>     // for replace, mismatch
+#include <cstdio>        // for snprintf
 #include <exception>     // for exception
 #include <filesystem>    // for path, operator==, exists, operator/, _Pat...
 #include <fmt/format.h>  // for check_format_string, format, vformat
@@ -24,20 +25,176 @@ void register_custom_require(sol::state& lua)
     lua.clear_package_loaders();
     lua.add_package_loader(custom_loader);
 
+    // The raw originals. These are kept out of script environments by the deny list in
+    // acquire_lua_vm, the wrappers below are what scripts get to see.
     lua["__require"] = lua["require"];
     lua["__loadlib"] = lua["package"]["loadlib"];
+    lua["__load"] = lua["load"];
+    lua["__loadfile"] = lua["loadfile"];
 
     /// Custom implementation to trick Lua into allowing to `require 'lib.module'` more than once given it was called from a different source
     lua["require"] = custom_require;
 
+    /// A chunk loaded by the stock load/loadfile/dofile gets the real _G as its _ENV, so these have to give the chunk the calling script's environment instead.
+    lua["load"] = custom_load;
+    lua["loadfile"] = custom_loadfile;
+    lua["dofile"] = custom_dofile;
+
     lua["package"]["loadlib"] = custom_loadlib;
+}
+
+namespace
+{
+/// Resolve a path passed to loadfile/dofile. Safe scripts may only reach files inside their own
+/// root and get relative paths resolved against it. Returns nullopt if a safe script tried to escape its root.
+std::optional<std::filesystem::path> resolve_chunk_path(std::string_view root, bool unsafe, const std::string& path)
+{
+    namespace fs = std::filesystem;
+
+    if (unsafe)
+        return fs::path{path};
+
+    // A script with no root of its own, like one from "Create new quick script", has no directory
+    // to be confined to, so it may load nothing. An empty base would pass the test below for any
+    // path at all.
+    if (root.empty())
+        return std::nullopt;
+
+    std::error_code ec;
+    const fs::path base = fs::absolute(fs::path{root}, ec).lexically_normal();
+    if (ec || base.empty())
+        return std::nullopt;
+
+    const fs::path requested{path};
+    const fs::path full = fs::absolute(requested.is_absolute() ? requested : base / requested, ec).lexically_normal();
+    if (ec)
+        return std::nullopt;
+
+    // lexically_relative handles a base that normalized with a trailing separator, as "." does,
+    // and gives an empty path when the two share no root, as across Windows drives.
+    const fs::path relative = full.lexically_relative(base);
+    if (relative.empty() || *relative.begin() == "..")
+        return std::nullopt;
+
+    return full;
+}
+
+/// Push the environment a freshly loaded chunk should run in onto L. Scripts may pass their own
+/// table.
+void push_chunk_env(lua_State* L, int env_idx)
+{
+    if (!lua_isnoneornil(L, env_idx))
+    {
+        lua_pushvalue(L, env_idx);
+        return;
+    }
+    LuaBackend::get_calling_backend()->lua.push(L);
+}
+} // namespace
+
+// These are raw lua_CFunctions, so sol wraps nothing around them, and Lua is built as C here, so
+// its error handling is setjmp based and cannot catch a C++ exception. One unwinding through the
+// interpreter's frames would leave the VM inconsistent, so anything thrown becomes a Lua error
+// raised after the C++ frames are gone. Nothing with a destructor stays alive across the final
+// lua_call for the same reason: that longjmps on error.
+int custom_load(lua_State* L)
+{
+    char err[512]{};
+    try
+    {
+        lua_settop(L, 4);
+
+        // Only ever accept source text. A precompiled chunk skips the parser entirely and can be
+        // crafted to corrupt the VM.
+        lua_pushliteral(L, "t");
+        lua_replace(L, 3);
+
+        push_chunk_env(L, 4);
+        lua_replace(L, 4);
+
+        {
+            sol::object raw_load = get_lua_vm()["__load"];
+            raw_load.push(L);
+        }
+        lua_insert(L, 1);
+    }
+    catch (const std::exception& e)
+    {
+        snprintf(err, sizeof(err), "%s", e.what());
+    }
+    if (err[0] != '\0')
+        return luaL_error(L, "%s", err);
+
+    lua_call(L, 4, LUA_MULTRET);
+    return lua_gettop(L);
+}
+int custom_loadfile(lua_State* L)
+{
+    char err[512]{};
+    try
+    {
+        const std::string requested = luaL_checkstring(L, 1);
+
+        std::optional<std::filesystem::path> resolved;
+        {
+            auto backend = LuaBackend::get_calling_backend();
+            resolved = resolve_chunk_path(backend->get_root(), backend->get_unsafe(), requested);
+        }
+
+        if (!resolved)
+        {
+            snprintf(err, sizeof(err), "Tried to load '%s' from outside the script root without unsafe mode.", requested.c_str());
+        }
+        else
+        {
+            const std::string resolved_str = resolved->string();
+
+            lua_settop(L, 3);
+            lua_pushlstring(L, resolved_str.c_str(), resolved_str.size());
+            lua_replace(L, 1);
+
+            lua_pushliteral(L, "t");
+            lua_replace(L, 2);
+
+            push_chunk_env(L, 3);
+            lua_replace(L, 3);
+
+            {
+                sol::object raw_loadfile = get_lua_vm()["__loadfile"];
+                raw_loadfile.push(L);
+            }
+            lua_insert(L, 1);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        snprintf(err, sizeof(err), "%s", e.what());
+    }
+    if (err[0] != '\0')
+        return luaL_error(L, "%s", err);
+
+    lua_call(L, 3, LUA_MULTRET);
+    return lua_gettop(L);
+}
+int custom_dofile(lua_State* L)
+{
+    lua_settop(L, 1);
+    custom_loadfile(L);
+    if (lua_gettop(L) != 1)
+        return lua_error(L);
+
+    lua_call(L, 0, LUA_MULTRET);
+    return lua_gettop(L);
 }
 sol::object custom_require(std::string path)
 {
     static sol::state& lua = get_lua_vm();
 
+    auto backend = LuaBackend::get_calling_backend();
+    const bool unsafe = backend->get_unsafe();
+
     if (path == "io" || path == "os" || path == "math" || path == "string" || path == "table" || path == "coroutine" || path == "package")
-        return lua[path];
+        return backend->lua[path];
 
     // Turn module into a real path
     {
@@ -50,8 +207,6 @@ sol::object custom_require(std::string path)
     }
 
     // Could be preloaded by some unsafe script, which can only be fetched by unsafe scripts
-    auto backend = LuaBackend::get_calling_backend();
-    const bool unsafe = backend->get_unsafe();
     if (unsafe)
     {
         auto preload = lua["package"]["preload"][path];
@@ -275,11 +430,13 @@ int custom_loader(lua_State* L)
             auto func = "luaopen_" + module;
             std::replace(func.begin(), func.end(), '/', '_');
             std::replace(func.begin(), func.end(), '.', '_');
-            sol::stack::push(L, backend->lua["__loadlib"](_path, func));
+            sol::stack::push(L, get_lua_vm()["__loadlib"](_path, func));
             return true;
         }
         _path += ext;
-        const auto res = luaL_loadfile(L, _path.c_str());
+        // "t" for the same reason as custom_load. luaL_loadfile defaults to "bt", which would let
+        // bytecode in through require and around the check the other loaders make.
+        const auto res = luaL_loadfilex(L, _path.c_str(), "t");
         if (res == LUA_OK)
         {
             backend->lua.push();

--- a/src/game_api/script/lua_require.hpp
+++ b/src/game_api/script/lua_require.hpp
@@ -13,3 +13,8 @@ void register_custom_require(sol::state& lua);
 sol::object custom_require(std::string path);
 sol::object custom_loadlib(std::string path, std::string func);
 int custom_loader(struct lua_State* L);
+
+// Same for the stock chunk loaders, which would otherwise give the chunk the real _G
+int custom_load(struct lua_State* L);
+int custom_loadfile(struct lua_State* L);
+int custom_dofile(struct lua_State* L);

--- a/src/game_api/script/lua_vm.cpp
+++ b/src/game_api/script/lua_vm.cpp
@@ -121,6 +121,52 @@ void load_unsafe_libraries(sol::state& lua)
     require_serpent_lua(lua);
     NSocket::register_usertypes(lua);
 }
+namespace
+{
+struct ImportResult
+{
+    sol::object exports;
+    bool found{false};
+    bool blocked_unsafe{false};
+    std::string id{};
+};
+
+/// Resolving an import enables the target if it is not already running. A safe script must not be
+/// able to start an unsafe one that way.
+ImportResult resolve_import(sol::state& vm, const std::string& id, std::string_view version)
+{
+    ImportResult result{};
+    result.exports = sol::make_object(vm, sol::lua_nil);
+    result.id = sanitize(id);
+
+    auto backend = LuaBackend::get_calling_backend();
+    backend->required_scripts.push_back(result.id);
+    const bool caller_unsafe = backend->get_unsafe();
+
+    auto import_backend_opt = LuaBackend::get_backend_by_id_safe(std::string_view(result.id), version);
+    if (!import_backend_opt.has_value())
+    {
+        return result;
+    }
+    result.found = true;
+    auto& import_backend = import_backend_opt.value();
+
+    if (!import_backend->get_enabled())
+    {
+        if (import_backend->get_unsafe() && !caller_unsafe)
+        {
+            result.blocked_unsafe = true;
+            return result;
+        }
+        import_backend->set_enabled(true);
+        import_backend->update();
+    }
+
+    result.exports = sol::make_object(vm, import_backend->lua["exports"]);
+    return result;
+}
+} // namespace
+
 void populate_lua_state(sol::state& lua, SoundManager* sound_manager)
 {
     auto infinite_loop = [](lua_State* argst, [[maybe_unused]] lua_Debug* argdb)
@@ -136,28 +182,44 @@ void populate_lua_state(sol::state& lua, SoundManager* sound_manager)
     lua_sethook(lua.lua_state(), infinite_loop, LUA_MASKCOUNT, 420000000);
 
     lua.safe_script(R"(
--- This function walks up the stack until it finds an _ENV that is not _G
--- That _ENV has to be the environment of a script where we can look up the scripts id
-get_script_id = function()
-    -- Not available in Lua 5.2+
-    local getfenv = getfenv or function(f)
-        f = (type(f) == 'function' and f or debug.getinfo(f + 1, 'f').func)
+-- This function walks up the stack and returns every _ENV that is not _G, nearest frame first.
+-- The backend takes the first one it knows as a script environment, rather than just the nearest,
+-- because a chunk can run in a derived environment that is not itself a script: the F-string
+-- library builds one per expression and load() takes one from the caller. Those resolve to the
+-- script underneath them.
+__get_script_envs = function()
+    -- Not available in Lua 5.2+, and it has to say whether the frame exists, so that running off
+    -- the top of the stack ends the loop instead of erroring
+    local frame_env = function(level)
+        local info = debug.getinfo(level + 1, 'f')
+        if not info then return false, nil end
         local name, val
         local up = 0
         repeat
             up = up + 1
-            name, val = debug.getupvalue(f, up)
+            name, val = debug.getupvalue(info.func, up)
         until name == '_ENV' or name == nil
-        return val
+        return true, val
     end
 
-    local env
+    local envs = {}
     local up = 1
-    repeat
+    while true do
         up = up + 1
-        env = getfenv(up)
-    until env ~= _G and env ~= nil
-    return env.__script_id
+        local exists, env = frame_env(up)
+        if not exists then break end
+        if env ~= nil and env ~= _G then
+            envs[#envs + 1] = env
+        end
+    end
+    return envs
+end
+
+-- For scripts that want to know their own id. Scripts can write to __script_id, so
+-- we don't rely on this value in the backend.
+get_script_id = function()
+    local env = __get_script_envs()[1]
+    return env and env.__script_id
 end
 )");
 
@@ -433,87 +495,67 @@ end
     /// Table of options set in the UI, added with the [register_option_functions](#Option-functions), but `nil` before any options are registered. You can also write your own options in here or override values defined in the register functions/UI before or after they are registered. Check the examples for many different use cases and saving options to disk.
     // lua["options"] = lua.create_named_table("options");
 
-    /// Load another script by id "author/name" and import its `exports` table. Returns:
+    /// Load another script by id "author/name" and import its `exports` table. Enables the imported
+    /// script if it isn't already, except when it is unsafe and yours is not, since enabling a script
+    /// runs it and only the user gets to make that call for an unsafe one. Returns:
     ///
     /// - `table` if the script has exports
     /// - `nil` if the script was found but has no exports
-    /// - `false` if the script was not found but optional is set to true
-    /// - an error if the script was not found and the optional argument was not set
+    /// - `false` if the script was not found, or is unsafe and not enabled, but optional is set to true
+    /// - an error if the script was not found, or is unsafe and not enabled, and the optional argument was not set
     // lua["import"] = [](string id, optional<string> version, optional<bool> optional) -> table
     lua["import"] = sol::overload(
         [&lua](std::string id)
         {
-            auto backend = LuaBackend::get_calling_backend();
-            backend->required_scripts.push_back(sanitize(id));
-            auto import_backend_opt = LuaBackend::get_backend_by_id_safe(std::string_view(sanitize(id)));
-            if (!import_backend_opt.has_value())
-            {
+            auto res = resolve_import(lua, id, "");
+            if (res.blocked_unsafe)
+                luaL_error(lua, "Tried to import unsafe script '%s' from a safe script. Enable it yourself first.", res.id.c_str());
+            if (!res.found)
                 luaL_error(lua, "Imported script not found");
-                return sol::make_object(lua, sol::lua_nil);
-            }
-            auto& import_backend = import_backend_opt.value();
-            if (!import_backend->get_enabled())
-            {
-                import_backend->set_enabled(true);
-                import_backend->update();
-            }
-            return sol::make_object(lua, import_backend->lua["exports"]);
+            return res.exports;
         },
         [&lua](std::string id, std::string version)
         {
-            auto backend = LuaBackend::get_calling_backend();
-            backend->required_scripts.push_back(sanitize(id));
-            auto import_backend_opt = LuaBackend::get_backend_by_id_safe(std::string_view(sanitize(id)), std::string_view(version));
-            if (!import_backend_opt.has_value())
-            {
+            auto res = resolve_import(lua, id, version);
+            if (res.blocked_unsafe)
+                luaL_error(lua, "Tried to import unsafe script '%s' from a safe script. Enable it yourself first.", res.id.c_str());
+            if (!res.found)
                 luaL_error(lua, "Imported script not found");
-                return sol::make_object(lua, sol::lua_nil);
-            }
-            auto& import_backend = import_backend_opt.value();
-            if (!import_backend->get_enabled())
-            {
-                import_backend->set_enabled(true);
-                import_backend->update();
-            }
-            return sol::make_object(lua, import_backend->lua["exports"]);
+            return res.exports;
         },
         [&lua](std::string id, std::string version, bool optional)
         {
-            auto backend = LuaBackend::get_calling_backend();
-            backend->required_scripts.push_back(sanitize(id));
-            auto import_backend_opt = LuaBackend::get_backend_by_id_safe(std::string_view(sanitize(id)), std::string_view(version));
-            if (!import_backend_opt.has_value())
+            auto res = resolve_import(lua, id, version);
+            if (res.blocked_unsafe)
+            {
+                if (!optional)
+                    luaL_error(lua, "Tried to import unsafe script '%s' from a safe script. Enable it yourself first.", res.id.c_str());
+                return sol::make_object(lua, false);
+            }
+            if (!res.found)
             {
                 if (!optional)
                     luaL_error(lua, "Imported script not found");
                 return sol::make_object(lua, false);
             }
-            auto& import_backend = import_backend_opt.value();
-            if (!import_backend->get_enabled())
-            {
-                import_backend->set_enabled(true);
-                import_backend->update();
-            }
-            return sol::make_object(lua, import_backend->lua["exports"]);
+            return res.exports;
         },
         [&lua](std::string id, bool optional)
         {
-            auto backend = LuaBackend::get_calling_backend();
-            backend->required_scripts.push_back(sanitize(id));
-            auto import_backend_opt = LuaBackend::get_backend_by_id_safe(std::string_view(sanitize(id)));
-            if (!import_backend_opt.has_value())
+            auto res = resolve_import(lua, id, "");
+            if (res.blocked_unsafe)
+            {
+                if (!optional)
+                    luaL_error(lua, "Tried to import unsafe script '%s' from a safe script. Enable it yourself first.", res.id.c_str());
+                return sol::make_object(lua, false);
+            }
+            if (!res.found)
             {
                 if (!optional)
                     luaL_error(lua, "Imported script not found");
                 return sol::make_object(lua, false);
             }
-            auto& import_backend = import_backend_opt.value();
-            if (!import_backend->get_enabled())
-            {
-                import_backend->set_enabled(true);
-                import_backend->update();
-            }
-            return sol::make_object(lua, import_backend->lua["exports"]);
+            return res.exports;
         });
 
     /// Deprecated
@@ -973,8 +1015,10 @@ end
         auto path = base / std::filesystem::path(dir.value_or("."));
         if (!std::filesystem::exists(path) || !std::filesystem::is_directory(path))
             return sol::make_object(lua, sol::lua_nil);
+        // relative() returns an empty path when it cannot express one, most commonly because the
+        // two are on different Windows drives, so an empty result is a failed check and not a pass
         auto base_check = std::filesystem::relative(path, base).string();
-        if (base_check.starts_with("..") && !backend->get_unsafe())
+        if ((base_check.empty() || base_check.starts_with("..")) && !backend->get_unsafe())
         {
             luaL_error(lua, "Tried to list parent directory without unsafe mode.");
             return sol::make_object(lua, sol::lua_nil);
@@ -1744,6 +1788,20 @@ std::recursive_mutex global_lua_lock;
 std::vector<std::string> safe_fields{};
 std::vector<std::string> unsafe_fields{};
 
+/// Globals that must never be copied into a script environment.
+/// The __ prefixed ones are the raw, unchecked originals that the wrappers in lua_require.cpp
+/// delegate to. Passing a script the real load/loadfile means giving it the real _G, allowing
+/// access to the global Lua state.
+constexpr std::string_view sandbox_denied[]{
+    "debug",
+    "package",
+    "__require",
+    "__loadlib",
+    "__load",
+    "__loadfile",
+    "__get_script_envs",
+};
+
 std::shared_ptr<sol::state> acquire_lua_vm(class SoundManager* sound_manager)
 {
     static std::shared_ptr<sol::state> global_vm = [sound_manager]()
@@ -1759,7 +1817,7 @@ std::shared_ptr<sol::state> acquire_lua_vm(class SoundManager* sound_manager)
             if (k.get_type() == sol::type::string)
             {
                 std::string_view key = k.as<std::string_view>();
-                if (key != "debug" && key != "package")
+                if (std::find(std::begin(sandbox_denied), std::end(sandbox_denied), key) == std::end(sandbox_denied))
                 {
                     safe_fields.push_back(std::string{key});
                 }

--- a/src/game_api/script/script_impl.cpp
+++ b/src/game_api/script/script_impl.cpp
@@ -47,7 +47,8 @@ ScriptImpl::ScriptImpl(std::string script, std::string file, SoundManager* sound
     enabled = enable;
 
     /// Table of strings where you should set some script metadata shown in the UI and used by other scripts to find your script.
-    lua["meta"] = get_lua_vm().create_named_table("meta");
+    sol::table meta_table{get_lua_vm(), sol::create};
+    lua["meta"] = meta_table;
 
     try
     {
@@ -83,7 +84,30 @@ ScriptImpl::ScriptImpl(std::string script, std::string file, SoundManager* sound
                 getmeta = false;
             }
         }
-        auto lua_result = execute_lua(lua, metacode);
+        // Every script on disk gets its metadata read at startup, long before the user has agreed
+        // to run any of it, and the extractor above is a line based guess that a script can talk
+        // into handing over more than just the meta lines. So metadata never runs in the script's
+        // own environment, it runs in this minimal environament.
+        sol::environment meta_env{get_lua_vm(), sol::create};
+        meta_env["meta"] = meta_table;
+
+        try
+        {
+            auto lua_result = execute_lua(meta_env, metacode);
+            result = "Got metadata";
+        }
+        catch (const sol::error& e)
+        {
+            set_error(e.what());
+        }
+
+        // `meta = { ... }` rebinds the name, so take whatever it ended up pointing at
+        sol::optional<sol::table> resolved_meta = meta_env["meta"];
+        if (resolved_meta)
+        {
+            lua["meta"] = resolved_meta.value();
+        }
+
         sol::optional<std::string> meta_name = lua["meta"]["name"];
         sol::optional<std::string> meta_version = lua["meta"]["version"];
         sol::optional<std::string> meta_description = lua["meta"]["description"];
@@ -98,8 +122,6 @@ ScriptImpl::ScriptImpl(std::string script, std::string file, SoundManager* sound
         meta.online_safe = meta_online_safe.value_or(false);
         meta.id = script_id();
         lua["__script_id"] = meta.file;
-
-        result = "Got metadata";
     }
     catch (const sol::error& e)
     {


### PR DESCRIPTION
We got a report of someone escaping the sandbox recently by calling a function that provides the full global environment. This led to an audit of the existing sandbox code and a cleanup of various potential escapes.

load, loadfile and dofile were on the whitelist. A chunk loaded through any of them gets the registry globals table as its _ENV, not the caller's environment, so `load("return io.open")()` was able to be used as an escape. They are now wrappers that default the chunk's environment to the calling script's env.

__require and __loadlib, the raw originals stashed for the require wrappers, were on the whitelist. __loadlib is package.loadlib, so a safe script could load and call into any DLL on disk. They are on the deny list now.

require("io") returned the global io table rather than the cut down one the script's environment holds. Same for os and package. It now returns whatever the caller already has.

serpent is on the whitelist too, and its load() deserializes into the real global table when given safe=false. Remove that option as an escape vector.

Script metadata is read for every .lua on disk at startup and multiline matching allows code to run before you've enabled a mod. Now run the metadata execution in an extremely isolated pure sandbox.

get_calling_backend_id trusted __script_id, a plain writable field of the script's environment allowing one script to spoof another. Callers are now identified by the env table they're running in.

Don't allow a safe script to import and unsafe script unless that script has already been enabled explicitly by the user.